### PR TITLE
docs(phase-4): defer cost capture + LlmJudge default guidance + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+  Pipewise PR template. Adapter-pattern + non-negotiables in CLAUDE.md
+  apply to every PR. Skim before submitting.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What this PR does and why. Link the issue with `Closes #N`. -->
+
+## Changes
+
+<!-- Bulleted list of the substantive changes. Skip mechanical formatting / lint-only churn. -->
+
+## How was this tested?
+
+<!-- Pre-push checklist: ruff check, ruff format --check, mypy, pytest. Note any local validation gates that ran. -->
+
+- [ ] `uv run ruff check pipewise/ tests/`
+- [ ] `uv run ruff format --check pipewise/ tests/`
+- [ ] `uv run mypy pipewise/`
+- [ ] `uv run pytest`
+
+## Architectural rules touched
+
+<!-- Tick anything this PR interacts with. If unsure, leave blank. -->
+
+- [ ] Adapter pattern (no pipeline-specific code in `pipewise/` core)
+- [ ] Schema (`PipelineRun`, `StepExecution`) — backward-compatibility implications?
+- [ ] Scorer protocol (`StepScorer`, `RunScorer`)
+- [ ] CLI surface (`inspect`, `eval`, `diff`)
+- [ ] Storage layout (timestamped, immutable reports)
+- [ ] None — internal change
+
+## Notes for the reviewer
+
+<!-- Optional. Tradeoffs considered, follow-up work intentionally deferred, anything non-obvious. -->

--- a/README.md
+++ b/README.md
@@ -77,10 +77,19 @@ Multi-step LLM pipelines silently break in ways that are nearly invisible until 
 
 - **Prompt edits cascade unpredictably.** Editing the prompt in step 3 of a 7-step pipeline can shift output distributions in step 5 without warning.
 - **Model swaps create silent drift.** Swapping Claude Opus → Sonnet for cost reasons can change a step's behavior subtly enough that no one notices for days.
-- **Cost is opaque.** Most teams know their total monthly API spend. Almost none can tell you which step in their pipeline costs 60% of the bill.
+- **Cost is opaque.** Most teams know their total monthly API spend. Almost none can tell you which step in their pipeline costs 60% of the bill. Pipewise's schema captures cost per step and `CostBudgetScorer` enforces budgets — *when your pipeline can measure it*. (See [Cost capture status](#cost-capture-status) below.)
 - **Existing eval tools assume single-prompt.** Promptfoo, Braintrust, LangSmith, and DeepEval were designed for testing one prompt → one output. They have to be contorted to evaluate multi-step pipelines, and the contortion loses fidelity at the step level.
 
-Pipewise treats the **pipeline run** as the unit of evaluation, with step-level scoring, cost attribution per step, and regression diffing across pipeline structure changes.
+Pipewise treats the **pipeline run** as the unit of evaluation, with step-level scoring, cost attribution support, and regression diffing across pipeline structure changes.
+
+## Cost capture status
+
+Pipewise's `PipelineRun` schema and `CostBudgetScorer` / `LatencyBudgetScorer` are ready to enforce budgets per step or per run. Whether they have data to enforce against depends on your pipeline:
+
+- **SDK-based pipelines** (direct `anthropic.messages.create(...)` calls or equivalent): your adapter can capture `usage.input_tokens` / `usage.output_tokens`, compute cost from a per-model price table, and populate `step.cost_usd` / `step.latency_ms`. Budget scorers work end-to-end.
+- **Claude-Code-orchestrated pipelines** (steps run as `.claude/agents/*.md` files): Claude Code does not currently expose per-agent usage telemetry to user code. Adapters for these pipelines populate cost fields with `None` and use `on_missing="skip"` on budget scorers. The schema is forward-compatible — once the data is available, no migration needed.
+
+Cost capture for Claude-Code-orchestrated pipelines is on the roadmap once either (a) Claude Code exposes per-agent usage telemetry, or (b) a contributor opens a PR with an SDK-based pipeline integration.
 
 ## How it's positioned vs. existing tools
 
@@ -99,6 +108,7 @@ Pipewise treats the **pipeline run** as the unit of evaluation, with step-level 
 - **Not a chatbot eval tool.** Pipewise's value starts at step count ≥ 2.
 - **Not a tracing/observability tool.** Use Langfuse, LangSmith, or Datadog LLM Observability for tracing. Pipewise consumes their output via an adapter; it doesn't replace them.
 - **Not coupled to any model provider.** Anthropic for the v1 `LlmJudgeScorer` only because that's what the maintainer has access to during development; pluggable from v1.1.
+- **Not a token-capture / instrumentation tool.** Pipewise consumes cost / latency / token data when your pipeline can measure it; it does not instrument your pipeline for you. SDK-based pipelines do this in the adapter; Claude-Code-orchestrated pipelines wait on upstream telemetry.
 
 ## The adapter pattern (the key architectural commitment)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Pipewise treats the **pipeline run** as the unit of evaluation, with step-level 
 
 Pipewise's `PipelineRun` schema and `CostBudgetScorer` / `LatencyBudgetScorer` are ready to enforce budgets per step or per run. Whether they have data to enforce against depends on your pipeline:
 
-- **SDK-based pipelines** (direct `anthropic.messages.create(...)` calls or equivalent): your adapter can capture `usage.input_tokens` / `usage.output_tokens`, compute cost from a per-model price table, and populate `step.cost_usd` / `step.latency_ms`. Budget scorers work end-to-end.
+- **SDK-based pipelines** (direct `anthropic.messages.create(...)` calls or equivalent): your adapter can capture `usage.input_tokens` / `usage.output_tokens`, compute cost from a per-model price table, and populate the cost/latency fields on both the steps (`step.cost_usd`, `step.latency_ms`) AND the run-level totals (`run.total_cost_usd`, `run.total_latency_ms`). The run-level totals are what `CostBudgetScorer` and `LatencyBudgetScorer` evaluate against. Budget scorers work end-to-end.
 - **Claude-Code-orchestrated pipelines** (steps run as `.claude/agents/*.md` files): Claude Code does not currently expose per-agent usage telemetry to user code. Adapters for these pipelines populate cost fields with `None` and use `on_missing="skip"` on budget scorers. The schema is forward-compatible — once the data is available, no migration needed.
 
 Cost capture for Claude-Code-orchestrated pipelines is on the roadmap once Claude Code exposes per-agent usage telemetry. (Separately, the cost-attribution path is also demonstrable in this repo as soon as a contributor opens a PR with an SDK-based pipeline integration — that's a different reference adapter, not a fix for the Claude Code path.)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pipewise's `PipelineRun` schema and `CostBudgetScorer` / `LatencyBudgetScorer` a
 - **SDK-based pipelines** (direct `anthropic.messages.create(...)` calls or equivalent): your adapter can capture `usage.input_tokens` / `usage.output_tokens`, compute cost from a per-model price table, and populate `step.cost_usd` / `step.latency_ms`. Budget scorers work end-to-end.
 - **Claude-Code-orchestrated pipelines** (steps run as `.claude/agents/*.md` files): Claude Code does not currently expose per-agent usage telemetry to user code. Adapters for these pipelines populate cost fields with `None` and use `on_missing="skip"` on budget scorers. The schema is forward-compatible — once the data is available, no migration needed.
 
-Cost capture for Claude-Code-orchestrated pipelines is on the roadmap once either (a) Claude Code exposes per-agent usage telemetry, or (b) a contributor opens a PR with an SDK-based pipeline integration.
+Cost capture for Claude-Code-orchestrated pipelines is on the roadmap once Claude Code exposes per-agent usage telemetry. (Separately, the cost-attribution path is also demonstrable in this repo as soon as a contributor opens a PR with an SDK-based pipeline integration — that's a different reference adapter, not a fix for the Claude Code path.)
 
 ## How it's positioned vs. existing tools
 

--- a/docs/scorers.md
+++ b/docs/scorers.md
@@ -3,6 +3,11 @@
 > Quick reference for the eight built-in scorers shipped in v1. For the
 > full schema and adapter contract, see [`schema.md`](schema.md) and
 > [`adapter-guide.md`](adapter-guide.md).
+>
+> **`LlmJudgeScorer` is the only scorer that calls a paid API.** Adapter
+> authors should NOT include it in `default_scorers()` — surprise API
+> costs hurt UX for first-time users. Document it as a recommended
+> opt-in; users enable it explicitly via `pipewise eval --scorers <toml>`.
 
 A scorer evaluates one aspect of a step or run. Pipewise ships two protocol shapes:
 
@@ -149,6 +154,8 @@ result = scorer.score(pipeline_run)
 
 When `total_cost_usd` is `None` (the adapter didn't capture it), default behavior is `on_missing="fail"` — silent passing on missing data masks real problems. Override with `on_missing="skip"` for adapters that don't track cost.
 
+> **Cost data unavailable for Claude-Code-orchestrated pipelines.** Pipelines whose steps run as Claude Code agents (or any tool that doesn't expose per-call usage to user code) cannot populate `total_cost_usd` in v1. Pipewise's schema and `CostBudgetScorer` are ready when the data is — but for these pipelines today, set `on_missing="skip"` in the adapter's `default_scorers()`. Cost capture is on the roadmap once Claude Code exposes per-agent usage telemetry, or a contributor adds an SDK-based pipeline integration.
+
 ## `LatencyBudgetScorer`
 
 Run-level scorer. Pass when `run.total_latency_ms <= budget_ms`.
@@ -160,7 +167,7 @@ scorer = LatencyBudgetScorer(budget_ms=30_000)
 result = scorer.score(pipeline_run)
 ```
 
-Same `on_missing` semantics as `CostBudgetScorer`.
+Same `on_missing` semantics as `CostBudgetScorer` — including the cost-data-unavailable note above for Claude-Code-orchestrated pipelines.
 
 ---
 

--- a/docs/scorers.md
+++ b/docs/scorers.md
@@ -154,7 +154,7 @@ result = scorer.score(pipeline_run)
 
 When `total_cost_usd` is `None` (the adapter didn't capture it), default behavior is `on_missing="fail"` — silent passing on missing data masks real problems. Override with `on_missing="skip"` for adapters that don't track cost.
 
-> **Cost data unavailable for Claude-Code-orchestrated pipelines.** Pipelines whose steps run as Claude Code agents (or any tool that doesn't expose per-call usage to user code) cannot populate `total_cost_usd` in v1. Pipewise's schema and `CostBudgetScorer` are ready when the data is — but for these pipelines today, set `on_missing="skip"` in the adapter's `default_scorers()`. Cost capture is on the roadmap once Claude Code exposes per-agent usage telemetry, or a contributor adds an SDK-based pipeline integration.
+> **Cost and latency data unavailable for Claude-Code-orchestrated pipelines.** Pipelines whose steps run as Claude Code agents (or any tool that doesn't expose per-call usage to user code) cannot populate `total_cost_usd` or `total_latency_ms` in v1. Pipewise's schema and budget scorers are ready when the data is — but for these pipelines today, set `on_missing="skip"` in the adapter's `default_scorers()`. This telemetry is on the roadmap once Claude Code exposes per-agent usage data; SDK-based reference integrations can demonstrate the feature path independently.
 
 ## `LatencyBudgetScorer`
 
@@ -167,7 +167,7 @@ scorer = LatencyBudgetScorer(budget_ms=30_000)
 result = scorer.score(pipeline_run)
 ```
 
-Same `on_missing` semantics as `CostBudgetScorer` — including the cost-data-unavailable note above for Claude-Code-orchestrated pipelines.
+Same `on_missing` semantics as `CostBudgetScorer` — including the cost-and-latency-data-unavailable note above for Claude-Code-orchestrated pipelines.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 4's first PR. Closes #28 (docs framing for cost-capture deferral) and adds the project's first PR template alongside it — pipewise switches from direct-to-main to PR-per-feature at Phase 4 per `CLAUDE.local.md` branching strategy.

## Changes

- `.github/pull_request_template.md` (new) — checklist for pre-push gates + architectural-rules tickboxes
- `docs/scorers.md` — `LlmJudgeScorer` defaults guidance + cost-data-unavailable note for `CostBudgetScorer` / `LatencyBudgetScorer`
- `README.md` — "Cost capture status" section drawing SDK vs. Claude-Code-orchestrated distinction; soften the cost bullet; add "not a token-capture tool" non-goal

## Why

Both planned reference adapters (FactSpark, resume-tailor) turned out to be Claude Code agent systems — no Python chokepoint to instrument for token capture. Per the LOCKED 2026-04-27 decision in `.local/BACKLOG.md`, cost capture for Claude-Code-orchestrated pipelines is deferred indefinitely rather than building fragile session-transcript scrapers. Public-facing docs need to match.

The schema is forward-compatible: when usage telemetry becomes available, adapters can populate cost fields with no migration needed.

## Plumbing not in this PR

Branch protection on `main` (require PR + CI green + linear history) couldn't be applied — permission gate blocked the API call. Will be applied via repo settings when the maintainer authorizes it.

## Test plan

- [x] `uv run ruff check pipewise/ tests/`
- [x] `uv run ruff format --check pipewise/ tests/`
- [x] `uv run mypy pipewise/`
- [x] `uv run pytest` — 357 passed, 1 skipped (doc-only diff, sanity check)
- [x] Privacy reviewer: clean

## Architectural rules touched

- [ ] Adapter pattern
- [ ] Schema
- [ ] Scorer protocol
- [ ] CLI surface
- [ ] Storage layout
- [x] None — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)