### PR TITLE
Phase 4 Pass 4: adapter-guide polish + validation gates (#29 #30 #31)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8b9c2661-5a71-44a2-8744-bdca96010a91","pid":576274,"procStart":"4139031","acquiredAt":1777299578121}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8b9c2661-5a71-44a2-8744-bdca96010a91","pid":576274,"procStart":"4139031","acquiredAt":1777299578121}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ htmlcov/
 .idea/
 .DS_Store
 Thumbs.db
+
+# Claude Code harness runtime state (not the project-committed agents / commands)
+.claude/scheduled_tasks.lock

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -1,50 +1,207 @@
 # Writing a pipewise adapter
 
-> **Status:** Stub. Full guide lands in Phase 1 alongside the schema, with a worked example in Phase 4 alongside the FactSpark and resume-tailor reference adapters.
+This guide walks through building a pipewise adapter using the two reference integrations as worked examples — a linear-ish 7-step pipeline (FactSpark, news analysis) and a branching/conditional pipeline (resume-tailor). Both adapters are about ~250 lines of Python with full test coverage; you should be able to ship one for your own pipeline in an afternoon.
 
 ## What an adapter does
 
-An adapter is a small piece of code that lives **inside the pipeline you want to evaluate** and converts that pipeline's outputs into a `pipewise.PipelineRun`. Pipewise core never imports your pipeline — your adapter imports pipewise.
+An adapter is a small Python package that lives **inside the pipeline you want to evaluate** and converts that pipeline's outputs into a `pipewise.PipelineRun`. Pipewise core never imports your pipeline — your adapter imports pipewise.
 
 ```
 your-pipeline-repo/
-  integrations/
-    pipewise/
-      adapter.py    ← reads your pipeline's output, returns PipelineRun
-      golden/       ← hand-curated expected runs
-      eval_config.yml
+└── integrations/
+    └── pipewise/
+        ├── pyproject.toml             # declares pipewise as a dependency
+        ├── README.md
+        ├── your_pipeline_pipewise/    # your package
+        │   ├── __init__.py
+        │   └── adapter.py             # exports load_run + default_scorers
+        └── tests/
+            └── test_adapter.py
 ```
 
 ## Why the adapter lives in your repo, not in pipewise
 
-This is the architectural commitment that makes pipewise's "general framework" claim verifiable. Your pipeline depends on pipewise (via `pip install pipewise`); pipewise has zero knowledge of your pipeline. A reviewer cloning the pipewise repo sees no traces of any specific pipeline in the core code.
+This is the architectural commitment that makes pipewise's "general framework" claim verifiable. Your pipeline depends on pipewise (via `pip install pipewise`); pipewise has zero knowledge of your pipeline. A reviewer cloning the pipewise repo sees no traces of any specific pipeline in the core code, and the `examples/` directory only links to external adapter implementations.
 
-## What the schema looks like (preview)
+It also keeps the dependency graph clean: pipewise stays small (no optional pipeline-specific extras to maintain), and your pipeline can iterate on its adapter without coordinating releases with pipewise.
+
+## The contract
+
+An adapter package exposes two functions at module level:
 
 ```python
-from pipewise import PipelineRun, StepExecution
+from pipewise import PipelineRun, RunScorer, StepScorer
 
-run = PipelineRun(
-    run_id="...",
-    pipeline_name="your-pipeline",
-    started_at=...,
-    steps=[
-        StepExecution(step_id="...", outputs={...}),
-        ...
-    ],
-    adapter_name="your-pipewise-adapter",
-    adapter_version="0.1.0",
-)
+def load_run(path: Path) -> PipelineRun:
+    """Read a single completed pipeline run from disk and translate it
+    into a PipelineRun. Pipewise's runner calls this once per row in the
+    eval dataset."""
+
+def default_scorers() -> tuple[list[StepScorer], list[RunScorer]]:
+    """Return the canonical scorer set for this pipeline. Used when
+    `pipewise eval` is invoked without `--scorers <toml>`."""
 ```
 
-The full schema reference, including field-by-field documentation, the
-schema-level conventions (`extra="forbid"`, `AwareDatetime`, etc.), and two
-worked examples (linear FactSpark-shape and branching resume-shape), lives
-at [**`docs/schema.md`**](schema.md).
+Both are required. Pipewise's `--adapter` flag accepts a dotted module path (e.g., `--adapter factspark_pipewise.adapter`) and resolves these names at module level via `importlib.import_module`.
+
+## Worked example 1 — FactSpark (linear pipeline)
+
+FactSpark is a 7-step news-analysis pipeline. Each step writes its output as JSON to `articles/<prefix>_step{N}.json`. Steps 1-6 propagate `full_article_content` forward; step 7 (Gemini-based claim verification) has a totally different output schema.
+
+The adapter (~250 LOC at `factspark-app/integrations/pipewise/factspark_pipewise/adapter.py` once that repo flips public alongside pipewise v1.0):
+
+```python
+# factspark_pipewise/adapter.py — abridged
+_STEP_LINEUP: list[tuple[str, str, str, str]] = [
+    ("analyze",            "analyze-article",            "claude-opus-4-7", "anthropic"),
+    ("enhance_entities",   "enhance-entities-geographic","claude-opus-4-7", "anthropic"),
+    ("enhance_content",    "enhance-content-assessment", "claude-opus-4-7", "anthropic"),
+    ("enhance_source",     "enhance-source-temporal",    "claude-opus-4-7", "anthropic"),
+    ("stupid_meter",       "stupid-meter",               "claude-opus-4-7", "anthropic"),
+    ("enhance_analytics_ui","enhance-analytics-ui",      "claude-opus-4-7", "anthropic"),
+    ("verify_claims",      "verify-claims",              "gemini-3.1-pro",  "google"),
+]
+
+def load_run(path: Path) -> PipelineRun:
+    prefix = Path(str(path)).name.removesuffix("_step1.json")
+    articles_dir, step_paths = _find_step_files(prefix)
+    base = datetime.fromtimestamp(step_paths[0].stat().st_mtime, tz=UTC)
+
+    steps: list[StepExecution] = []
+    for i, ((step_id, executor, model, provider), step_path) in enumerate(
+        zip(_STEP_LINEUP, step_paths, strict=True)
+    ):
+        if not step_path.exists():
+            steps.append(StepExecution(
+                step_id=step_id, step_name=step_id.replace("_", " ").title(),
+                started_at=base + timedelta(seconds=i * 10), completed_at=None,
+                status="failed", error=f"step{i + 1}.json missing",
+                executor=executor, model=model, provider=provider,
+            ))
+            continue
+        outputs = json.loads(step_path.read_text(encoding="utf-8"))
+        steps.append(StepExecution(
+            step_id=step_id, step_name=step_id.replace("_", " ").title(),
+            started_at=base + timedelta(seconds=i * 10),
+            completed_at=base + timedelta(seconds=(i * 10) + 5),
+            status="completed", executor=executor, model=model, provider=provider,
+            outputs=outputs,
+        ))
+
+    return PipelineRun(
+        run_id=prefix, pipeline_name="factspark",
+        started_at=base, completed_at=base + timedelta(seconds=70),
+        status="completed" if all(s.status == "completed" for s in steps) else "partial",
+        steps=steps, final_output=steps[-1].outputs,
+        adapter_name="factspark-pipewise-adapter", adapter_version="0.1.0",
+    )
+```
+
+Things worth noting:
+
+- **Stable `step_id`s, not "step_N".** The schema reasons about "did the same step run last time?" via `step_id`, so meaningful names (`analyze`, `verify_claims`) outlive renames in the source pipeline.
+- **`executor` matches the source agent's filename stem** — adapter-guide readers and ops folks see the same names in pipewise reports as in `.claude/agents/`.
+- **Timestamps are synthesized** because FactSpark doesn't record per-step start times. The adapter uses each step file's mtime as a stand-in. This is a common shape for Claude-Code-orchestrated pipelines (no per-call telemetry; see "Cost capture" below).
+- **Mid-run failure is recorded, not raised.** A missing step file becomes `status="failed"` with an `error` message; the run continues and is marked `status="partial"`.
+
+## Worked example 2 — resume-tailor (branching pipeline)
+
+The resume-tailor pipeline is a 7-step Claude Code agent system that tailors a resume to a specific job posting. Compared to FactSpark, it stresses three additional schema-level concerns:
+
+- **Optional steps:** step 2 (discover experience) is sometimes skipped for straightforward roles.
+- **Branching / conditional steps:** step 4 (write chronological resume) and step 4b (write hybrid resume) are mutually exclusive — both write to `step4.json`, distinguished by a `resume_format` field.
+- **Mixed JSON / Markdown:** steps 1-5 are JSON; step 6 produces cover-letter and application-response Markdown; step 7 (Canva export) has no filesystem output.
+
+The adapter (lives at `job-search/integrations/pipewise/resume_tailor_pipewise/adapter.py` — public alongside pipewise v1.0) records the conditional shape by **always emitting both step IDs** with one marked `status="skipped"`:
+
+```python
+# resume_tailor_pipewise/adapter.py — abridged
+chronological_taken, _ = _resolve_step4_format(step3, step4)
+
+if chronological_taken:
+    steps.append(_make_step(
+        step_id="write_resume_chronological",
+        step_name="Write Resume (Chronological)",
+        executor="resume-step4-write-resume",
+        started_at=at(30), duration_s=5, status="completed", outputs=step4,
+    ))
+    steps.append(_make_step(
+        step_id="write_resume_hybrid",
+        step_name="Write Resume (Hybrid)",
+        executor="resume-step4b-write-resume-hybrid",
+        started_at=at(40), duration_s=0, status="skipped",
+    ))
+else:  # hybrid taken
+    steps.append(_make_step(
+        step_id="write_resume_chronological",
+        step_name="Write Resume (Chronological)",
+        executor="resume-step4-write-resume",
+        started_at=at(30), duration_s=0, status="skipped",
+    ))
+    steps.append(_make_step(
+        step_id="write_resume_hybrid",
+        step_name="Write Resume (Hybrid)",
+        executor="resume-step4b-write-resume-hybrid",
+        started_at=at(40), duration_s=5, status="completed", outputs=step4,
+    ))
+```
+
+The two-step-IDs-with-one-skipped pattern is what lets `pipewise diff` surface a format flip between runs as a status change — the most readable kind of regression signal.
+
+For the optional-step case (step 2), the adapter emits a single step entry whose status switches with the source data:
+
+```python
+if step2 is None:                           # step2.json absent on disk
+    steps.append(_make_step(step_id="discover_experience", status="skipped", ...))
+else:
+    steps.append(_make_step(step_id="discover_experience", status="completed", outputs=step2, ...))
+```
+
+For step 7 (apply_to_canva), the adapter always emits `status="skipped"` because the canonical store is Canva, not the filesystem. This makes the pipeline's true shape visible in pipewise reports — operators reading the report shouldn't have to remember "Canva exists outside our schema."
+
+## The `default_scorers()` contract
+
+`default_scorers()` returns the canonical scorer set used by `pipewise eval` when no `--scorers <toml>` is supplied. Both reference adapters follow the same pattern:
+
+```python
+def default_scorers() -> tuple[list[StepScorer], list[RunScorer]]:
+    step_scorers: list[StepScorer] = [
+        RegexScorer(field="full_article_content", pattern=r".{100,}",
+                    name="article-body-present"),
+    ]
+    run_scorers: list[RunScorer] = [
+        CostBudgetScorer(budget_usd=1.0,    on_missing="skip", name="cost-cap"),
+        LatencyBudgetScorer(budget_ms=120_000, on_missing="skip", name="latency-cap"),
+    ]
+    return step_scorers, run_scorers
+```
+
+**Convention: exclude `LlmJudgeScorer` from defaults.** It's the only built-in scorer that calls a paid API, and surprise costs hurt UX for first-time users. Power users opt in explicitly via `pipewise eval --scorers <toml>`. (See `docs/scorers.md` for the matching guidance on scorer config files.)
+
+**Convention: pick step-level scorers that produce a meaningful pass/fail signal, not all-pass-or-all-fail.** FactSpark's `article-body-present` regex passes on steps 1-6 (where `full_article_content` propagates) and fails on step 7 (different schema) — six passes plus one fail per run is a real eval signature, and a future regression that breaks propagation surfaces immediately. For the resume-tailor adapter, the equivalent is an adapter-derived `_company` field flattened onto every step's outputs (including skipped ones), which produces an all-pass baseline that catches propagation regressions cleanly.
+
+**Convention: budget scorers use `on_missing="skip"` when cost / latency data isn't available.** Both reference pipelines run inside Claude Code, which doesn't currently expose per-agent usage telemetry to user code — see the "Cost capture status" section in pipewise's README for the full deferral story. Adapters set `cost_usd` / `latency_ms` to `None` and rely on `on_missing="skip"` so the budget scorers register the *intent* without producing fake failures. When telemetry becomes available, the only change needed is `on_missing="fail"`.
+
+## Cost / latency / tokens
+
+Pipewise's schema has first-class fields for cost, latency, and token counts (`StepExecution.cost_usd`, `latency_ms`, `input_tokens`, `output_tokens`, plus run-level totals). When your pipeline captures this data, populate it — the budget scorers and any future cost-aware reporting come along for free.
+
+When your pipeline *doesn't* capture this data (e.g., Claude Code agents in v1), leave those fields as `None` and use `on_missing="skip"` on the budget scorers. Pipewise's schema is forward-compatible: turning the data on later is purely additive — no adapter contract changes, no schema migrations.
+
+## Testing your adapter
+
+Both reference adapters ship with a `tests/test_adapter.py` covering:
+
+- `load_run` against synthetic step files in `tmp_path` (always-runs)
+- `load_run` against real pipeline output (skipped when the canonical local data isn't present)
+- `default_scorers()` shape: list types, no `LlmJudgeScorer`, budget scorers use `on_missing="skip"`
+- End-to-end `run_eval` round-trip against synthetic runs
+
+Pipewise itself ships matching gate tests in `tests/integration/test_phase4_*_gate.py` that drive `pipewise.run_eval` through the production adapters end-to-end on real pipeline data — they skip cleanly on contributor machines without local pipeline data.
 
 ## Reference adapters
 
-- **FactSpark** — `github.com/isthatamullet/factspark/tree/main/integrations/pipewise` (link goes live after Phase 4)
-- **Resume-tailor** — `github.com/isthatamullet/tyler/tree/main/integrations/pipewise` (link goes live after Phase 4)
+Both reference adapters ship in their own pipeline repos and go public alongside pipewise v1.0. See [`examples/README.md`](../examples/README.md) for the canonical list, and [`docs/schema.md`](schema.md) for the field-by-field schema reference.
 
-See `examples/README.md` in this repo for the up-to-date list.
+- **FactSpark** — linear-ish 7-step news-analysis pipeline, mixed Anthropic / Google models
+- **Resume-tailor** — branching/conditional pipeline with optional steps and Markdown side-products

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,17 @@
 # Example integrations
 
-> **Status:** Reference adapters land in Phase 4 of the build (see `PLAN.md §6`).
+Pipewise's adapter pattern means reference integrations live **inside the pipelines they adapt**, not in this repo. This page is just an index pointing at them.
 
-Pipewise's adapter pattern means reference integrations live **inside the pipelines they adapt**, not in this repo. This page is just an index linking out to them.
+## Reference adapters
 
-## Reference adapters (coming in Phase 4)
+Both reference adapters ship in their own pipeline repos and go public alongside pipewise v1.0.
 
 | Pipeline | Domain | Shape | Adapter location |
 |---|---|---|---|
-| **FactSpark** | News article analysis | 7 steps, mostly linear, all-JSON | `github.com/isthatamullet/factspark/tree/main/integrations/pipewise` |
-| **Resume-tailor** | Job application tailoring | 7 agents, branching + conditional, mixed JSON/Markdown/PDF | `github.com/isthatamullet/tyler/tree/main/integrations/pipewise` |
+| **FactSpark** | News article analysis | 7 steps, linear-ish, all-JSON, mixed Anthropic / Google models | `factspark-app/integrations/pipewise/` |
+| **Resume-tailor** | Job application tailoring | 7 agents, branching + conditional, optional steps, mixed JSON / Markdown side-products | `job-search/integrations/pipewise/` |
+
+Both adapters are about ~250 lines of Python with full test coverage. Together they exercise the abstraction across two meaningfully different pipeline shapes — see [`docs/adapter-guide.md`](../docs/adapter-guide.md) for a walkthrough of the conditional-step / branching pattern the resume-tailor adapter uses.
 
 ## Writing your own
 

--- a/tests/integration/test_phase4_factspark_gate.py
+++ b/tests/integration/test_phase4_factspark_gate.py
@@ -1,0 +1,174 @@
+"""Phase 4 validation gate (issue #30): drive `pipewise.run_eval` end-to-end
+through the **real** FactSpark adapter.
+
+This is the production-shape test, not the Phase 1 prototype gate
+(`test_factspark_validation_gate.py`). It imports `factspark_pipewise.adapter`
+— the adapter package shipped at `factspark/integrations/pipewise/` — and
+exercises:
+
+- `load_run` on real FactSpark step-JSON artifacts
+- `default_scorers()` returning the canonical defaults
+- `pipewise.runner.eval.run_eval` driving those scorers across multiple runs
+- `EvalReport.model_dump_json` / `model_validate_json` round-trip with no
+  data loss (the same immutability guarantee Phase 1 #6 verified for raw runs,
+  now extended to the report layer)
+
+Skips automatically when the FactSpark articles dir is absent OR when the
+adapter package isn't installed (`uv pip install -e ~/factspark/integrations/pipewise/`).
+Pipewise core has zero runtime dependency on FactSpark; this test runs locally
+only — never on CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from pipewise.core.report import EvalReport
+from pipewise.core.schema import PipelineRun
+
+_FACTSPARK_ARTICLES_DIR = Path.home() / "factspark" / "articles"
+
+# A small dataset of real FactSpark articles. Each prefix is a known-good run
+# whose step1-7.json files are present in the articles dir. The adapter
+# resolves them by prefix; pipewise then runs scorers across all three.
+_REFERENCE_PREFIXES: tuple[str, ...] = (
+    "02242026_bbc_trump_tariffs_supreme_court",
+    "02252026_apnews_trump_sotu_fact_check",
+    "02252026_whitehouse_sotu_democrat_response",
+)
+
+
+def _adapter_module() -> object | None:
+    """Return the installed adapter module, or None when unavailable.
+
+    The adapter ships as a separate package outside pipewise (`factspark/
+    integrations/pipewise/`), and contributors who don't have FactSpark
+    locally won't have it installed. Skip-on-ImportError keeps the gate
+    friendly without weakening the assertions when the package IS installed.
+    """
+    try:
+        return importlib.import_module("factspark_pipewise")
+    except ImportError:
+        return None
+
+
+_ADAPTER = _adapter_module()
+_AVAILABLE_PREFIXES: tuple[str, ...] = tuple(
+    p for p in _REFERENCE_PREFIXES if (_FACTSPARK_ARTICLES_DIR / f"{p}_step1.json").exists()
+)
+
+pytestmark = pytest.mark.skipif(
+    _ADAPTER is None or len(_AVAILABLE_PREFIXES) < 2,
+    reason=(
+        "Phase 4 FactSpark gate runs locally only — requires both the real "
+        "factspark_pipewise adapter to be installed AND >=2 reference "
+        "articles present in ~/factspark/articles/."
+    ),
+)
+
+
+def _load_real_runs() -> list[PipelineRun]:
+    """Build a small dataset of real FactSpark runs via the production adapter."""
+    assert _ADAPTER is not None  # pytestmark guarantees this; mypy/runtime sanity.
+    runs = [
+        _ADAPTER.load_run(_FACTSPARK_ARTICLES_DIR / f"{prefix}_step1.json")  # type: ignore[attr-defined]
+        for prefix in _AVAILABLE_PREFIXES
+    ]
+    return runs
+
+
+def test_real_adapter_produces_valid_pipeline_runs() -> None:
+    """The production adapter's `load_run` returns schema-conforming runs."""
+    runs = _load_real_runs()
+    assert len(runs) >= 2
+    for run in runs:
+        assert isinstance(run, PipelineRun)
+        assert run.pipeline_name == "factspark"
+        assert run.adapter_name == "factspark-pipewise-adapter"
+        assert len(run.steps) == 7  # FactSpark canonical shape
+
+
+def test_default_scorers_drive_run_eval_end_to_end() -> None:
+    """Using `default_scorers()` (no `--scorers` override), `run_eval`
+    produces the expected per-run report shape.
+
+    Mirrors the in-adapter eval test (`factspark/integrations/pipewise/tests/
+    test_adapter.py::TestEndToEndEval`), but covers a multi-run dataset and
+    drives the pipewise runner directly so the abstraction is exercised
+    in the same configuration the CLI would use.
+    """
+    assert _ADAPTER is not None
+    from pipewise.runner.eval import run_eval
+
+    runs = _load_real_runs()
+    step_scorers, run_scorers = _ADAPTER.default_scorers()  # type: ignore[attr-defined]
+
+    report = run_eval(runs, step_scorers, run_scorers, dataset_name="phase4-factspark-gate")
+
+    assert isinstance(report, EvalReport)
+    assert len(report.runs) == len(runs)
+    # Per-run: 1 step scorer x 7 steps + 2 run scorers = 9 score entries.
+    for run_result in report.runs:
+        assert len(run_result.step_scores) == 7
+        assert len(run_result.run_scores) == 2
+
+    # FactSpark's `article-body-present` regex passes on steps 1-6
+    # (full_article_content propagated forward) and fails on step 7
+    # (Gemini verifier, different schema). Same pattern as the
+    # in-adapter test, now verified against the production runner on
+    # multiple real articles.
+    for run_result in report.runs:
+        passes = sum(1 for r in run_result.step_scores if r.result.passed)
+        fails = sum(1 for r in run_result.step_scores if not r.result.passed)
+        assert passes == 6
+        assert fails == 1
+
+
+def test_eval_report_round_trips_without_data_loss(tmp_path: Path) -> None:
+    """`EvalReport` survives JSON serialization end-to-end, including the
+    nested `ScoreResult.metadata` dicts each scorer attaches.
+
+    This is the storage-layer contract pipewise's `report storage` (Phase 3
+    #23) relies on. If `EvalReport` round-trips cleanly here on real adapter
+    output, the storage path is provably whole.
+    """
+    assert _ADAPTER is not None
+    from pipewise.runner.eval import run_eval
+
+    runs = _load_real_runs()
+    step_scorers, run_scorers = _ADAPTER.default_scorers()  # type: ignore[attr-defined]
+    report = run_eval(runs, step_scorers, run_scorers, dataset_name="phase4-factspark-roundtrip")
+
+    serialized = report.model_dump_json()
+    restored = EvalReport.model_validate_json(serialized)
+    assert restored == report
+
+    # Disk round-trip — the same write/read pattern `pipewise.runner.report_storage`
+    # uses for timestamped report files.
+    out_path = tmp_path / "report.json"
+    out_path.write_text(serialized, encoding="utf-8")
+    on_disk = EvalReport.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert on_disk == report
+
+
+def test_run_status_and_step_outputs_consistent_with_source_artifacts() -> None:
+    """Every step's outputs equals the source step-JSON byte-for-byte.
+
+    The production adapter doesn't massage the data on the way through
+    (no schema normalization, no field renames). This pins that contract
+    against silent regressions.
+    """
+    import json
+
+    runs = _load_real_runs()
+    for run in runs:
+        for i, step in enumerate(run.steps):
+            source = json.loads(
+                (_FACTSPARK_ARTICLES_DIR / f"{run.run_id}_step{i + 1}.json").read_text()
+            )
+            assert step.outputs == source, (
+                f"{run.run_id}/step{i + 1}: adapter outputs diverge from source JSON"
+            )

--- a/tests/integration/test_phase4_factspark_gate.py
+++ b/tests/integration/test_phase4_factspark_gate.py
@@ -167,7 +167,9 @@ def test_run_status_and_step_outputs_consistent_with_source_artifacts() -> None:
     for run in runs:
         for i, step in enumerate(run.steps):
             source = json.loads(
-                (_FACTSPARK_ARTICLES_DIR / f"{run.run_id}_step{i + 1}.json").read_text()
+                (_FACTSPARK_ARTICLES_DIR / f"{run.run_id}_step{i + 1}.json").read_text(
+                    encoding="utf-8"
+                )
             )
             assert step.outputs == source, (
                 f"{run.run_id}/step{i + 1}: adapter outputs diverge from source JSON"

--- a/tests/integration/test_phase4_resume_tailor_gate.py
+++ b/tests/integration/test_phase4_resume_tailor_gate.py
@@ -1,0 +1,258 @@
+"""Phase 4 validation gate (issue #31): drive `pipewise.run_eval` end-to-end
+through the **real** resume-tailor adapter.
+
+This is the production-shape test, not the Phase 1 prototype gate
+(`test_resume_validation_gate.py`). It imports `resume_tailor_pipewise.adapter`
+— the adapter package shipped at `job-search/integrations/pipewise/` — and
+exercises the meaningfully harder pipeline shape the resume-tailor pipeline
+introduces:
+
+- **Branching** (write_resume_chronological vs write_resume_hybrid mutex)
+- **Optional steps** (discover_experience often skipped)
+- **Mixed JSON / Markdown** (step 1-5 are JSON, step 6's outputs are
+  cover-letter + application-responses Markdown)
+- **Always-skipped steps** (apply_to_canva — Canva has no filesystem
+  output for the adapter to read)
+
+Pairs with `test_phase4_factspark_gate.py` — together they're the proof
+that pipewise's adapter contract handles fundamentally different pipeline
+shapes via near-identical adapter code (the abstraction-correctness claim
+in the README).
+
+Skips automatically when the resumes dir is absent OR when the adapter
+package isn't installed (`uv pip install -e <job-search>/integrations/pipewise/`).
+
+The test deliberately discovers reference runs *dynamically* — it scans
+the local resumes dir, classifies each run by `(resume_format, step2_status)`,
+and picks the first run from each shape category. This keeps real personal
+job-application targets out of pipewise's committed test history while still
+exercising the adapter against real production data.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from pipewise.core.report import EvalReport
+from pipewise.core.schema import PipelineRun
+
+_RESUMES_DIR = Path.home() / "tyler" / "jobs" / "resumes"
+
+# Shape categories the gate aims to exercise. Each category is a
+# (resume_format, step2_status) pair that the adapter should distinguish.
+# We pick at most one run per category from whatever's locally available so
+# the test runs against real production data without committing the
+# specific run identifiers.
+_SHAPE_CATEGORIES: tuple[tuple[str, str], ...] = (
+    ("HYBRID", "skipped"),
+    ("CHRONOLOGICAL", "completed"),
+    ("CHRONOLOGICAL", "skipped"),
+)
+
+
+def _adapter_module() -> object | None:
+    """Return the installed adapter module, or None when unavailable."""
+    try:
+        return importlib.import_module("resume_tailor_pipewise")
+    except ImportError:
+        return None
+
+
+_ADAPTER = _adapter_module()
+
+
+def _discover_reference_runs() -> list[PipelineRun]:
+    """Walk the local resumes dir and pick at most one run per shape category.
+
+    Returns an empty list when the resumes dir is absent. Returns whatever
+    real runs are available when present — the gate's `pytestmark` skip
+    handles the "not enough coverage" case.
+    """
+    if _ADAPTER is None or not _RESUMES_DIR.exists():
+        return []
+    seen: dict[tuple[str, str], PipelineRun] = {}
+    for company_dir in sorted(_RESUMES_DIR.iterdir()):
+        if not company_dir.is_dir():
+            continue
+        for step1_path in sorted(company_dir.glob("*_step1.json")):
+            try:
+                run: PipelineRun = _ADAPTER.load_run(step1_path)  # type: ignore[attr-defined]
+            except Exception:
+                continue
+            fmt = run.metadata.get("resume_format")
+            if not isinstance(fmt, str):
+                continue
+            step2 = next(
+                (s for s in run.steps if s.step_id == "discover_experience"),
+                None,
+            )
+            if step2 is None:
+                continue
+            # Only accept runs whose step4 branches resolved cleanly — a
+            # mid-failure run isn't useful for asserting the mutex contract.
+            if not any(
+                s.step_id in {"write_resume_chronological", "write_resume_hybrid"}
+                and s.status == "completed"
+                for s in run.steps
+            ):
+                continue
+            key = (fmt, step2.status)
+            if key in _SHAPE_CATEGORIES and key not in seen:
+                seen[key] = run
+            if len(seen) == len(_SHAPE_CATEGORIES):
+                break
+        if len(seen) == len(_SHAPE_CATEGORIES):
+            break
+    return list(seen.values())
+
+
+_DISCOVERED_RUNS = _discover_reference_runs()
+
+pytestmark = pytest.mark.skipif(
+    _ADAPTER is None or len(_DISCOVERED_RUNS) < 2,
+    reason=(
+        "Phase 4 resume-tailor gate runs locally only — requires both the "
+        "real resume_tailor_pipewise adapter to be installed AND >=2 "
+        "reference runs spanning distinct (resume_format, step2_status) "
+        "categories present locally."
+    ),
+)
+
+
+def test_real_adapter_produces_valid_pipeline_runs() -> None:
+    """`load_run` returns schema-conforming runs with the canonical 8-step shape."""
+    runs = _DISCOVERED_RUNS
+    assert len(runs) >= 2
+
+    expected_step_ids = [
+        "analyze_posting",
+        "discover_experience",
+        "match_experience",
+        "write_resume_chronological",
+        "write_resume_hybrid",
+        "hiring_manager_critique",
+        "format_export",
+        "apply_to_canva",
+    ]
+    for run in runs:
+        assert isinstance(run, PipelineRun)
+        assert run.pipeline_name == "resume-tailor"
+        assert run.adapter_name == "resume-tailor-pipewise-adapter"
+        assert [s.step_id for s in run.steps] == expected_step_ids
+
+
+def test_branching_is_mutex_across_runs() -> None:
+    """For every run, exactly one of step4 / step4b is `completed` — the
+    other is `skipped`. This is the schema-level encoding of the conditional
+    branch (see `PipelineRun` docstring: "Branches and conditional steps are
+    captured by which `step_id` actually ran; skips are recorded with
+    `status='skipped'`")."""
+    for run in _DISCOVERED_RUNS:
+        chronological = next(s for s in run.steps if s.step_id == "write_resume_chronological")
+        hybrid = next(s for s in run.steps if s.step_id == "write_resume_hybrid")
+        completed_branches = [s for s in (chronological, hybrid) if s.status == "completed"]
+        assert len(completed_branches) == 1, (
+            "expected exactly one completed step4 branch, "
+            f"got chronological={chronological.status}, hybrid={hybrid.status}"
+        )
+
+
+def test_discovered_runs_span_distinct_shape_categories() -> None:
+    """The dynamic discovery picks at most one run per shape category. This
+    test pins that the categories represented are actually distinct — if a
+    future adapter regression collapses HYBRID and CHRONOLOGICAL detection
+    into the same value, we'd see all runs land in one category and this
+    fails loudly."""
+    categories = {(run.metadata["resume_format"], _step2_status(run)) for run in _DISCOVERED_RUNS}
+    assert len(categories) >= 2, (
+        f"expected >=2 distinct (resume_format, step2_status) categories, got {sorted(categories)}"
+    )
+
+
+def _step2_status(run: PipelineRun) -> str:
+    return next(s.status for s in run.steps if s.step_id == "discover_experience")
+
+
+def test_default_scorers_drive_run_eval_end_to_end() -> None:
+    """`default_scorers()` + `run_eval` produces the report shape pipewise's
+    CLI relies on for `pipewise eval`."""
+    assert _ADAPTER is not None
+    from pipewise.runner.eval import run_eval
+
+    runs = _DISCOVERED_RUNS
+    step_scorers, run_scorers = _ADAPTER.default_scorers()  # type: ignore[attr-defined]
+    report = run_eval(runs, step_scorers, run_scorers, dataset_name="phase4-resume-tailor-gate")
+
+    assert isinstance(report, EvalReport)
+    assert len(report.runs) == len(runs)
+    # Per-run: 1 step scorer x 8 steps + 2 run scorers = 10 entries.
+    for run_result in report.runs:
+        assert len(run_result.step_scores) == 8
+        assert len(run_result.run_scores) == 2
+
+    # The adapter populates `_company` on every step (including skipped ones)
+    # so the company-propagated check passes uniformly on healthy runs.
+    # Budget scorers run with `on_missing="skip"` because Claude Code doesn't
+    # expose per-call usage in v1 — those pass too.
+    for run_result in report.runs:
+        assert all(r.result.passed for r in run_result.step_scores), (
+            "company-propagated step check failed unexpectedly"
+        )
+        assert all(r.result.passed for r in run_result.run_scores), (
+            "budget run-scorer failed unexpectedly"
+        )
+
+
+def test_eval_report_round_trips_without_data_loss(tmp_path: Path) -> None:
+    """`EvalReport` survives JSON serialization end-to-end. Same contract as
+    the FactSpark gate (#30), but here the report includes step entries with
+    `status="skipped"` and Markdown content in `format_export.outputs` —
+    different shapes than FactSpark's all-completed all-JSON runs."""
+    assert _ADAPTER is not None
+    from pipewise.runner.eval import run_eval
+
+    runs = _DISCOVERED_RUNS
+    step_scorers, run_scorers = _ADAPTER.default_scorers()  # type: ignore[attr-defined]
+    report = run_eval(runs, step_scorers, run_scorers, dataset_name="phase4-resume-roundtrip")
+
+    serialized = report.model_dump_json()
+    restored = EvalReport.model_validate_json(serialized)
+    assert restored == report
+
+    out_path = tmp_path / "report.json"
+    out_path.write_text(serialized, encoding="utf-8")
+    on_disk = EvalReport.model_validate_json(out_path.read_text(encoding="utf-8"))
+    assert on_disk == report
+
+
+def test_step6_markdown_content_preserved_when_present() -> None:
+    """Step 6 (format_export) wraps cover_letter / application_responses /
+    formatted-resume Markdown as string fields. Verify at least one of the
+    runs has populated step 6 content and that it survives the schema layer
+    intact (no encoding mangling, no truncation)."""
+    runs_with_step6 = [
+        run
+        for run in _DISCOVERED_RUNS
+        if next(s for s in run.steps if s.step_id == "format_export").status == "completed"
+    ]
+    if not runs_with_step6:
+        pytest.skip(
+            "None of the discovered runs have step 6 outputs — skipping the "
+            "Markdown-preservation assertion. (Step 6 produces side-products "
+            "like cover letters and is only run on demand.)"
+        )
+    markdown_fields = {"cover_letter_md", "application_responses_md", "formatted_resume_md"}
+    for run in runs_with_step6:
+        step6 = next(s for s in run.steps if s.step_id == "format_export")
+        present = markdown_fields & set(step6.outputs)
+        assert present, (
+            "step 6 completed but no markdown fields present in outputs "
+            f"(got keys: {sorted(step6.outputs)})"
+        )
+        for field in present:
+            value = step6.outputs[field]
+            assert isinstance(value, str)
+            assert len(value) > 0


### PR DESCRIPTION
## Summary

Closes the third and final Pass of Phase 4 — replaces the prototype `docs/adapter-guide.md` with real worked examples and adds production-shape Phase 4 validation gates that drive `pipewise.run_eval` end-to-end through both reference adapters.

Closes #29, #30, #31.

## What's in here

### `docs/adapter-guide.md` (#29)
- Phase 1 stub replaced with a full guide that uses the two reference adapters as worked examples
- Linear-pipeline walkthrough (FactSpark) + branching-pipeline walkthrough (resume-tailor — step 4 vs 4b mutex via two step IDs with one always skipped; optional step 2; always-skipped step 7)
- `default_scorers()` contract documented with concrete examples
- No-token-capture pattern documented with forward-compat phrasing
- Reference adapter table includes both repos; live links omitted until those repos go public alongside v1.0

### `tests/integration/test_phase4_factspark_gate.py` (#30)
End-to-end gate driving `run_eval` through `factspark_pipewise.adapter`:
- 4 tests; skips automatically when adapter isn't installed or <2 reference articles present
- Verifies the expected pass/fail signature (article-body-present passes on steps 1-6, fails on step 7)
- EvalReport round-trips through `model_dump_json` + disk write/read with no data loss
- Step outputs equal source step-JSON byte-for-byte

### `tests/integration/test_phase4_resume_tailor_gate.py` (#31)
End-to-end gate driving `run_eval` through `resume_tailor_pipewise.adapter`:
- 6 tests; exercises branching, optional steps, mixed JSON/Markdown, always-skipped steps
- Reference runs **discovered dynamically** by `(resume_format, step2_status)` shape categories — keeps personal job-application identifiers out of pipewise's public test history while still exercising real production data
- Verifies branching mutex (exactly one of step4/step4b completed per run) and shape-category coverage

## Validation

- [x] `pytest -q` — 367 passing, 1 skipped (matches main; +10 new tests in the gates)
- [x] `ruff check . && ruff format --check .` — clean across 54 files
- [x] `mypy pipewise/` — clean (22 source files)
- [x] Privacy reviewer pass — surfaced and addressed two concerns (downgraded private-repo links to plain text; replaced hardcoded company fixture with dynamic shape-category discovery)
- [x] Phase 4 gates run locally and skip cleanly on contributor checkouts without local pipeline data

## End of Phase 4

After this lands, two BACKLOG triggers fire (per `CLAUDE.local.md`):
- First git tag (`v0.0.1+`)
- Demo video / GIF for pipewise README

Phase 5 (GitHub Action for PR-comment eval reports) is the next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)