### PR TITLE
Phase 5 #36: EvalReport → markdown PR comment renderer

### DIFF
--- a/pipewise/ci/__init__.py
+++ b/pipewise/ci/__init__.py
@@ -1,0 +1,5 @@
+"""CI integration helpers — render reports for external CI systems."""
+
+from pipewise.ci.github_action import render_pr_comment
+
+__all__ = ["render_pr_comment"]

--- a/pipewise/ci/github_action.py
+++ b/pipewise/ci/github_action.py
@@ -97,6 +97,18 @@ def _render_verdict_line(report: EvalReport, diff: ReportDiff | None) -> str:
         plural = "" if improvements == 1 else "s"
         return f"✅ All scorers passing · {improvements} improvement{plural} 🟢"
 
+    # At this point: no regressions, no failing, no improvements. But scores
+    # may have moved (`score_deltas`), or scorers/runs may have been added or
+    # removed. Any of those means "no regressions" is honest; "no change" is
+    # a lie. Reserve "no change vs main" for the truly identical case.
+    if (
+        diff.score_deltas
+        or diff.absent_in_a
+        or diff.absent_in_b
+        or diff.runs_a_only
+        or diff.runs_b_only
+    ):
+        return "✅ All scorers passing · no regressions vs main"
     return "✅ All scorers passing · no change vs main"
 
 
@@ -131,13 +143,19 @@ def _format_score(score: float | None) -> str:
     return f"{score:.2f}"
 
 
+# Epsilon for treating floating-point deltas as "no change". Scores live in
+# [0.0, 1.0] and the rendered cell shows two decimal places, so anything
+# smaller than 1e-6 is precision noise from averaging — not a real signal.
+_DELTA_EPSILON = 1e-6
+
+
 def _format_delta(baseline: float | None, current: float | None) -> str:
     if current is None:
         return "removed"
     if baseline is None:
         return "newly added"
     delta = current - baseline
-    if delta == 0.0:
+    if abs(delta) < _DELTA_EPSILON:
         return "—"
     sign = "+" if delta > 0 else ""
     emoji = "🟢" if delta > 0 else "🔴"
@@ -189,14 +207,42 @@ def _count_unchanged(report: EvalReport, baseline: EvalReport, diff: ReportDiff)
     return max(matched_in_report - changed, 0)
 
 
+def _format_extras_line(diff: ReportDiff) -> str | None:
+    """Footnote listing diff categories not surfaced in the main counts row.
+
+    The main row tracks regressions / improvements / unchanged (strict pass-
+    fail framing). Score-only deltas, newly-added scorers, and removed
+    scorers are real changes too — without surfacing them, the displayed
+    counts won't sum to the number of rows in the rollup table when those
+    categories are non-empty. Returns `None` when nothing to report.
+    """
+    extras: list[str] = []
+    if diff.score_deltas:
+        n = len(diff.score_deltas)
+        extras.append(f"{n} score delta{'' if n == 1 else 's'}")
+    if diff.absent_in_a:
+        n = len(diff.absent_in_a)
+        extras.append(f"{n} newly added")
+    if diff.absent_in_b:
+        n = len(diff.absent_in_b)
+        extras.append(f"{n} removed")
+    if not extras:
+        return None
+    return f"_Plus: {', '.join(extras)}._"
+
+
 def _render_counts(report: EvalReport, baseline: EvalReport | None, diff: ReportDiff) -> str:
     assert baseline is not None  # narrowed by call site
     unchanged = _count_unchanged(report, baseline, diff)
-    return (
+    line = (
         f"**Regressions:** {len(diff.regressions)} 🔴 · "
         f"**Improvements:** {len(diff.improvements)} 🟢 · "
         f"**Unchanged:** {unchanged}"
     )
+    extras = _format_extras_line(diff)
+    if extras is not None:
+        line += f"\n\n{extras}"
+    return line
 
 
 # ─── Newly-failing checks detail ─────────────────────────────────────────────

--- a/pipewise/ci/github_action.py
+++ b/pipewise/ci/github_action.py
@@ -1,0 +1,260 @@
+"""Render an `EvalReport` (with optional baseline) as a markdown PR comment.
+
+Phase 5 #36. Produces the sticky comment that the pipewise-eval GitHub Action
+posts on every PR. Format follows conventions distilled from prior art
+(Braintrust, Codecov, Vercel): sticky-comment HTML marker keyed by adapter
+name, verdict line as the most prominent element, scorer × step roll-up
+table with signed Δ column, per-case detail in collapsibles.
+
+The renderer is pure-Python and takes pre-built `EvalReport` objects;
+fetching reports from artifacts and posting comments via the GitHub API is
+the Action's responsibility (see `.github/actions/pipewise-eval/`, #37).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from pipewise import __version__ as _PIPEWISE_VERSION
+from pipewise.core.report import EvalReport
+from pipewise.core.scorer import ScoreResult
+from pipewise.runner.diff import ReportDiff, ScoreDiffEntry, compute_diff
+
+_STICKY_MARKER_TEMPLATE = "<!-- pipewise-eval-report:{adapter_name} -->"
+
+
+def render_pr_comment(
+    report: EvalReport,
+    *,
+    adapter_name: str,
+    short_sha: str,
+    baseline: EvalReport | None = None,
+) -> str:
+    """Render a markdown PR comment for `report`, optionally diffed against `baseline`.
+
+    Args:
+        report: The eval report from the current PR's pipeline run.
+        adapter_name: The adapter package name. Used as the sticky-comment marker
+            key so multi-adapter repos can post multiple comments without
+            clobbering. Also shown in the comment header.
+        short_sha: Short Git SHA of the commit this report was generated for.
+            Shown in the footer for staleness verification by reviewers.
+        baseline: The eval report from the comparison reference (typically main).
+            If `None`, the comment shows absolute values with no Δ column.
+
+    Returns:
+        Markdown string ready to post as a GitHub PR comment. Always ends in
+        a single trailing newline.
+    """
+    diff = compute_diff(baseline, report) if baseline is not None else None
+
+    parts: list[str] = [
+        _STICKY_MARKER_TEMPLATE.format(adapter_name=adapter_name),
+        f"## Pipewise eval report — {adapter_name}",
+        "",
+        _render_verdict_line(report, diff),
+        "",
+        _render_rollup_table(report, baseline),
+        "",
+    ]
+
+    if diff is not None:
+        parts.append(_render_counts(report, baseline, diff))
+        parts.append("")
+        if diff.regressions:
+            parts.append(_render_newly_failing(diff.regressions))
+            parts.append("")
+
+    parts.append(_render_full_report_details(report))
+    parts.append("")
+    parts.append(_render_footer(short_sha))
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# ─── Verdict line ────────────────────────────────────────────────────────────
+
+
+def _render_verdict_line(report: EvalReport, diff: ReportDiff | None) -> str:
+    if diff is None:
+        passing = report.passing_score_count()
+        total = report.total_score_count()
+        run_word = "run" if len(report.runs) == 1 else "runs"
+        return f"🆕 {len(report.runs)} {run_word} · {passing}/{total} scorers passing · no baseline"
+
+    if diff.regressions:
+        n = len(diff.regressions)
+        plural = "" if n == 1 else "s"
+        return f"❌ {n} regression{plural} · was passing on main, failing here"
+
+    failing = report.failing_score_count()
+    if failing > 0:
+        plural = "" if failing == 1 else "s"
+        return f"⚠️ {failing} failing scorer{plural} · no regressions vs main"
+
+    improvements = len(diff.improvements)
+    if improvements > 0:
+        plural = "" if improvements == 1 else "s"
+        return f"✅ All scorers passing · {improvements} improvement{plural} 🟢"
+
+    return "✅ All scorers passing · no change vs main"
+
+
+# ─── Roll-up table ───────────────────────────────────────────────────────────
+
+_RollupKey = tuple[str | None, str]
+
+
+def _aggregate_scores(report: EvalReport) -> dict[_RollupKey, list[ScoreResult]]:
+    """Bucket every `ScoreResult` by (step_id, scorer_name).
+
+    `step_id=None` represents run-level scorers.
+    """
+    buckets: dict[_RollupKey, list[ScoreResult]] = defaultdict(list)
+    for run in report.runs:
+        for step_entry in run.step_scores:
+            buckets[(step_entry.step_id, step_entry.scorer_name)].append(step_entry.result)
+        for run_entry in run.run_scores:
+            buckets[(None, run_entry.scorer_name)].append(run_entry.result)
+    return buckets
+
+
+def _avg_score(results: list[ScoreResult]) -> float | None:
+    if not results:
+        return None
+    return sum(r.score for r in results) / len(results)
+
+
+def _format_score(score: float | None) -> str:
+    if score is None:
+        return "—"
+    return f"{score:.2f}"
+
+
+def _format_delta(baseline: float | None, current: float | None) -> str:
+    if current is None:
+        return "removed"
+    if baseline is None:
+        return "newly added"
+    delta = current - baseline
+    if delta == 0.0:
+        return "—"
+    sign = "+" if delta > 0 else ""
+    emoji = "🟢" if delta > 0 else "🔴"
+    return f"{sign}{delta:.2f} {emoji}"
+
+
+def _format_rollup_label(step_id: str | None, scorer_name: str) -> str:
+    if step_id is None:
+        return f"`{scorer_name}` (run-level)"
+    return f"`{scorer_name}` × `{step_id}`"
+
+
+def _sort_rollup_keys(keys: set[_RollupKey]) -> list[_RollupKey]:
+    # Run-level entries (step_id=None) sort before step-level. Within each
+    # group, alphabetical by step_id then scorer_name. Matches `compute_diff`'s
+    # ordering convention for consistency between the table and the diff.
+    return sorted(keys, key=lambda k: (k[0] is not None, k[0] or "", k[1]))
+
+
+def _render_rollup_table(report: EvalReport, baseline: EvalReport | None) -> str:
+    report_buckets = _aggregate_scores(report)
+    baseline_buckets = _aggregate_scores(baseline) if baseline is not None else {}
+    all_keys = set(report_buckets) | set(baseline_buckets)
+
+    if not all_keys:
+        return "_No scorer results in this report._"
+
+    has_baseline = baseline is not None
+    lines = ["| Scorer × Step | Main | This PR | Δ |", "| :--- | ---: | ---: | ---: |"]
+    for key in _sort_rollup_keys(all_keys):
+        step_id, scorer_name = key
+        report_avg = _avg_score(report_buckets.get(key, []))
+        baseline_avg = _avg_score(baseline_buckets.get(key, []))
+        label = _format_rollup_label(step_id, scorer_name)
+        main_cell = _format_score(baseline_avg) if has_baseline else "—"
+        pr_cell = _format_score(report_avg)
+        delta_cell = _format_delta(baseline_avg, report_avg) if has_baseline else "—"
+        lines.append(f"| {label} | {main_cell} | {pr_cell} | {delta_cell} |")
+    return "\n".join(lines)
+
+
+# ─── Counts row ──────────────────────────────────────────────────────────────
+
+
+def _count_unchanged(report: EvalReport, baseline: EvalReport, diff: ReportDiff) -> int:
+    """Entries present in both reports with same pass status AND same score."""
+    matched_in_report = report.total_score_count() - len(diff.absent_in_a)
+    changed = len(diff.regressions) + len(diff.improvements) + len(diff.score_deltas)
+    return max(matched_in_report - changed, 0)
+
+
+def _render_counts(report: EvalReport, baseline: EvalReport | None, diff: ReportDiff) -> str:
+    assert baseline is not None  # narrowed by call site
+    unchanged = _count_unchanged(report, baseline, diff)
+    return (
+        f"**Regressions:** {len(diff.regressions)} 🔴 · "
+        f"**Improvements:** {len(diff.improvements)} 🟢 · "
+        f"**Unchanged:** {unchanged}"
+    )
+
+
+# ─── Newly-failing checks detail ─────────────────────────────────────────────
+
+
+def _format_regression_line(entry: ScoreDiffEntry) -> str:
+    location = f"`{entry.scorer_name}`"
+    if entry.step_id is not None:
+        location += f" × `{entry.step_id}`"
+    location += f" · run `{entry.run_id}`"
+    return f"- {location} — score {entry.score_a:.2f} → {entry.score_b:.2f} (passed → failed)"
+
+
+def _render_newly_failing(regressions: list[ScoreDiffEntry]) -> str:
+    n = len(regressions)
+    body = "\n".join(_format_regression_line(e) for e in regressions)
+    return f"<details><summary><b>Newly failing checks ({n})</b></summary>\n\n{body}\n\n</details>"
+
+
+# ─── Full report detail ──────────────────────────────────────────────────────
+
+
+def _render_full_report_details(report: EvalReport) -> str:
+    n_runs = len(report.runs)
+    run_word = "run" if n_runs == 1 else "runs"
+    dataset = report.dataset_name or "—"
+    summary = f"<summary>Full report ({n_runs} {run_word} · dataset: {dataset})</summary>"
+
+    if not report.runs:
+        return f"<details>{summary}\n\n_No runs in this report._\n\n</details>"
+
+    rows = [
+        "| Run | Step | Scorer | Score | Passed |",
+        "| :--- | :--- | :--- | ---: | :---: |",
+    ]
+    for run in report.runs:
+        for step_entry in sorted(run.step_scores, key=lambda e: (e.step_id, e.scorer_name)):
+            rows.append(
+                f"| `{run.run_id}` | `{step_entry.step_id}` | `{step_entry.scorer_name}` "
+                f"| {step_entry.result.score:.2f} | "
+                f"{'✅' if step_entry.result.passed else '❌'} |"
+            )
+        for run_entry in sorted(run.run_scores, key=lambda e: e.scorer_name):
+            rows.append(
+                f"| `{run.run_id}` | _(run-level)_ | `{run_entry.scorer_name}` "
+                f"| {run_entry.result.score:.2f} | "
+                f"{'✅' if run_entry.result.passed else '❌'} |"
+            )
+
+    body = "\n".join(rows)
+    return f"<details>{summary}\n\n{body}\n\n</details>"
+
+
+# ─── Footer ──────────────────────────────────────────────────────────────────
+
+
+def _render_footer(short_sha: str) -> str:
+    return f"<sub>Updated for `{short_sha}` · pipewise v{_PIPEWISE_VERSION}</sub>"
+
+
+__all__ = ["render_pr_comment"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,14 @@ ignore = [
     "E501",  # line too long (handled by formatter)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# `pipewise/ci/github_action.py` renders user-facing markdown that uses `×`
+# (multiplication sign) intentionally for the "Scorer × Step" matrix label —
+# matches typography conventions in similar PR-comment bots (Braintrust,
+# Codecov). Allow it in this module and its tests.
+"pipewise/ci/github_action.py" = ["RUF001", "RUF002"]
+"tests/ci/test_github_action.py" = ["RUF001"]
+
 [tool.ruff.format]
 quote-style = "double"
 

--- a/tests/ci/test_github_action.py
+++ b/tests/ci/test_github_action.py
@@ -1,0 +1,400 @@
+"""Tests for `pipewise.ci.github_action.render_pr_comment` (#36)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pipewise import (
+    EvalReport,
+    RunEvalResult,
+    RunScoreEntry,
+    ScoreResult,
+    StepScoreEntry,
+)
+from pipewise.ci import render_pr_comment
+
+NOW = datetime(2026, 4, 29, 12, 0, 0, tzinfo=UTC)
+
+
+def _result(score: float, passed: bool) -> ScoreResult:
+    return ScoreResult(score=score, passed=passed)
+
+
+def _step_entry(step_id: str, scorer_name: str, score: float, passed: bool) -> StepScoreEntry:
+    return StepScoreEntry(step_id=step_id, scorer_name=scorer_name, result=_result(score, passed))
+
+
+def _run_entry(scorer_name: str, score: float, passed: bool) -> RunScoreEntry:
+    return RunScoreEntry(scorer_name=scorer_name, result=_result(score, passed))
+
+
+def _run(
+    *,
+    run_id: str = "run_1",
+    step_scores: list[StepScoreEntry] | None = None,
+    run_scores: list[RunScoreEntry] | None = None,
+) -> RunEvalResult:
+    return RunEvalResult(
+        run_id=run_id,
+        pipeline_name="factspark",
+        adapter_name="factspark_pipewise",
+        adapter_version="0.0.1",
+        step_scores=step_scores or [],
+        run_scores=run_scores or [],
+    )
+
+
+def _report(
+    *,
+    runs: list[RunEvalResult],
+    dataset_name: str | None = "golden.jsonl",
+) -> EvalReport:
+    return EvalReport(
+        report_id="test-report",
+        generated_at=NOW,
+        pipewise_version="0.0.1",
+        dataset_name=dataset_name,
+        scorer_names=["any"],
+        runs=runs,
+    )
+
+
+# ─── Reference state A: passing, no change vs main ───────────────────────────
+
+
+class TestPassingNoChange:
+    def _identical_pair(self) -> tuple[EvalReport, EvalReport]:
+        run_steps = [
+            _step_entry("extract", "ExactMatch", 0.94, True),
+            _step_entry("analyze", "LlmJudge", 0.88, True),
+            _step_entry("format", "Regex", 1.00, True),
+        ]
+        baseline = _report(runs=[_run(run_id="r1", step_scores=run_steps)])
+        report = _report(runs=[_run(run_id="r1", step_scores=list(run_steps))])
+        return baseline, report
+
+    def test_verdict_says_no_change(self) -> None:
+        baseline, report = self._identical_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+        )
+        assert "✅ All scorers passing · no change vs main" in out
+
+    def test_delta_column_shows_dash_for_unchanged(self) -> None:
+        baseline, report = self._identical_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+        )
+        # Three rollup rows; each Δ cell should be the em-dash placeholder.
+        # Match `| — |` at line ends (the trailing pipe of the Δ column).
+        assert out.count("| — |") >= 3
+
+    def test_counts_show_zero_regressions_zero_improvements(self) -> None:
+        baseline, report = self._identical_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+        )
+        assert "**Regressions:** 0 🔴" in out
+        assert "**Improvements:** 0 🟢" in out
+        assert "**Unchanged:** 3" in out
+
+    def test_no_newly_failing_section_when_no_regressions(self) -> None:
+        baseline, report = self._identical_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+        )
+        assert "Newly failing checks" not in out
+
+
+# ─── Reference state B: passing with improvements ────────────────────────────
+
+
+class TestPassingWithImprovements:
+    def _improved_pair(self) -> tuple[EvalReport, EvalReport]:
+        # Two scorers improved by flipping fail→pass; one unchanged.
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[
+                        _step_entry("extract", "ExactMatch", 0.40, False),
+                        _step_entry("analyze", "LlmJudge", 0.45, False),
+                        _step_entry("format", "Regex", 1.00, True),
+                    ],
+                )
+            ]
+        )
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[
+                        _step_entry("extract", "ExactMatch", 0.97, True),
+                        _step_entry("analyze", "LlmJudge", 0.91, True),
+                        _step_entry("format", "Regex", 1.00, True),
+                    ],
+                )
+            ]
+        )
+        return baseline, report
+
+    def test_verdict_announces_improvements(self) -> None:
+        baseline, report = self._improved_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="def5678"
+        )
+        assert "✅ All scorers passing · 2 improvements 🟢" in out
+
+    def test_delta_column_shows_signed_positives(self) -> None:
+        baseline, report = self._improved_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="def5678"
+        )
+        assert "+0.57 🟢" in out  # 0.97 - 0.40
+        assert "+0.46 🟢" in out  # 0.91 - 0.45
+
+    def test_counts_show_two_improvements_one_unchanged(self) -> None:
+        baseline, report = self._improved_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="def5678"
+        )
+        assert "**Regressions:** 0 🔴" in out
+        assert "**Improvements:** 2 🟢" in out
+        assert "**Unchanged:** 1" in out
+
+
+# ─── Reference state C: regressing with newly-failing checks ─────────────────
+
+
+class TestRegressing:
+    def _regressed_pair(self) -> tuple[EvalReport, EvalReport]:
+        # One true regression (pass→fail) + one score_delta with negative delta.
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[
+                        _step_entry("extract", "ExactMatch", 0.94, True),
+                        _step_entry("analyze", "LlmJudge", 0.88, True),
+                        _step_entry("format", "Regex", 1.00, True),
+                    ],
+                )
+            ]
+        )
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[
+                        _step_entry("extract", "ExactMatch", 0.81, True),
+                        _step_entry("analyze", "LlmJudge", 0.85, True),
+                        _step_entry("format", "Regex", 0.45, False),
+                    ],
+                )
+            ]
+        )
+        return baseline, report
+
+    def test_verdict_announces_regressions(self) -> None:
+        baseline, report = self._regressed_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+        )
+        assert out.startswith("<!-- pipewise-eval-report:factspark -->")
+        assert "❌ 1 regression · was passing on main, failing here" in out
+
+    def test_delta_column_shows_signed_negatives_with_red_emoji(self) -> None:
+        baseline, report = self._regressed_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+        )
+        assert "-0.55 🔴" in out  # 0.45 - 1.00 (the regression)
+        assert "-0.13 🔴" in out  # 0.81 - 0.94 (score delta)
+        assert "-0.03 🔴" in out  # 0.85 - 0.88 (score delta)
+
+    def test_newly_failing_section_lists_regression_with_run_id(self) -> None:
+        baseline, report = self._regressed_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+        )
+        assert "<details><summary><b>Newly failing checks (1)</b></summary>" in out
+        assert "`Regex` × `format`" in out
+        assert "run `r1`" in out
+        assert "passed → failed" in out
+
+    def test_counts_show_one_regression(self) -> None:
+        baseline, report = self._regressed_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+        )
+        assert "**Regressions:** 1 🔴" in out
+        assert "**Improvements:** 0 🟢" in out
+
+
+# ─── Missing baseline ────────────────────────────────────────────────────────
+
+
+class TestNoBaseline:
+    def test_verdict_announces_no_baseline(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 0.94, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc1234")
+        assert "🆕 1 run · 1/1 scorers passing · no baseline" in out
+
+    def test_no_counts_row_when_baseline_missing(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 0.94, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc1234")
+        # Counts row only renders with a baseline.
+        assert "**Regressions:**" not in out
+        assert "**Improvements:**" not in out
+
+    def test_delta_column_shows_dash_when_baseline_missing(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 0.94, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc1234")
+        # Main column should be `—` and Δ column should be `—`.
+        assert "| — | 0.94 | — |" in out
+
+
+# ─── Structural / cross-cutting checks ───────────────────────────────────────
+
+
+class TestStructure:
+    def test_sticky_marker_is_first_line_and_keyed_by_adapter_name(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 1.0, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="my-adapter", short_sha="abc")
+        assert out.startswith("<!-- pipewise-eval-report:my-adapter -->\n")
+
+    def test_h2_header_includes_adapter_name(self) -> None:
+        report = _report(runs=[_run(run_id="r1")])
+        out = render_pr_comment(report, adapter_name="resume_tailor", short_sha="abc")
+        assert "## Pipewise eval report — resume_tailor" in out
+
+    def test_short_sha_appears_in_footer(self) -> None:
+        report = _report(runs=[_run(run_id="r1")])
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="deadbee")
+        assert "<sub>Updated for `deadbee` ·" in out
+
+    def test_run_level_scorers_appear_with_run_level_label(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    run_scores=[_run_entry("CostBudget", 1.0, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        assert "`CostBudget` (run-level)" in out
+
+    def test_rollup_header_uses_right_aligned_separators(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 1.0, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        # Right-aligned numeric columns per the locked design spec.
+        assert "| :--- | ---: | ---: | ---: |" in out
+
+    def test_full_report_details_lists_each_case(self) -> None:
+        report = _report(
+            runs=[
+                _run(
+                    run_id="run_a",
+                    step_scores=[
+                        _step_entry("s1", "ExactMatch", 0.9, True),
+                        _step_entry("s2", "Regex", 0.5, False),
+                    ],
+                ),
+                _run(
+                    run_id="run_b",
+                    step_scores=[
+                        _step_entry("s1", "ExactMatch", 1.0, True),
+                    ],
+                ),
+            ]
+        )
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        assert "<summary>Full report (2 runs · dataset: golden.jsonl)</summary>" in out
+        assert "`run_a` | `s1` | `ExactMatch`" in out
+        assert "`run_a` | `s2` | `Regex`" in out
+        assert "`run_b` | `s1` | `ExactMatch`" in out
+        # Pass/fail emoji per row.
+        assert " ✅ |" in out
+        assert " ❌ |" in out
+
+    def test_output_ends_with_single_trailing_newline(self) -> None:
+        report = _report(runs=[_run(run_id="r1")])
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        assert out.endswith("\n")
+        assert not out.endswith("\n\n")
+
+    def test_dataset_name_falls_back_to_dash_when_missing(self) -> None:
+        report = _report(runs=[_run(run_id="r1")], dataset_name=None)
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        assert "dataset: —" in out
+
+    def test_empty_report_renders_gracefully(self) -> None:
+        report = _report(runs=[])
+        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        # No table rows but header + placeholder still renders.
+        assert "_No scorer results in this report._" in out
+        assert "_No runs in this report._" in out
+
+
+# ─── Failing-but-not-regressed (warning) state ───────────────────────────────
+
+
+class TestFailingButNoRegressions:
+    def test_verdict_warns_when_failing_already_failing(self) -> None:
+        # Scorer was already failing on main and is still failing here.
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 0.20, False)],
+                )
+            ]
+        )
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("extract", "ExactMatch", 0.20, False)],
+                )
+            ]
+        )
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        assert "⚠️ 1 failing scorer · no regressions vs main" in out

--- a/tests/ci/test_github_action.py
+++ b/tests/ci/test_github_action.py
@@ -372,6 +372,164 @@ class TestStructure:
         assert "_No runs in this report._" in out
 
 
+# ─── Floating-point precision robustness ─────────────────────────────────────
+
+
+class TestFloatingPointPrecision:
+    def test_tiny_precision_error_renders_as_unchanged_dash(self) -> None:
+        # Realistic scenario: an average of 0.7 + 0.7 + 0.7 / 3 vs 2.1 / 3
+        # produces a microscopic precision delta. The cell should still
+        # render the em-dash "no change" placeholder, not "+0.00 🟢".
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("step", "Scorer", 0.7, True)],
+                ),
+                _run(
+                    run_id="r2",
+                    step_scores=[_step_entry("step", "Scorer", 0.7, True)],
+                ),
+                _run(
+                    run_id="r3",
+                    step_scores=[_step_entry("step", "Scorer", 0.7, True)],
+                ),
+            ]
+        )
+        # Same logical average, written as 2.1/3 (introduces precision noise).
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("step", "Scorer", 0.1, True)],
+                ),
+                _run(
+                    run_id="r2",
+                    step_scores=[_step_entry("step", "Scorer", 1.0, True)],
+                ),
+                _run(
+                    run_id="r3",
+                    step_scores=[_step_entry("step", "Scorer", 1.0, True)],
+                ),
+            ]
+        )
+        # Sanity: the average difference IS exactly 0 in arithmetic but may
+        # not be exactly 0 in float. Average baseline = 0.7; average report =
+        # (0.1 + 1.0 + 1.0) / 3 = 0.7 (with possible precision noise).
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        # The Δ cell should be "—" (not "+0.00 🟢" or similar).
+        assert "+0.00 🟢" not in out
+        assert "-0.00 🔴" not in out
+
+
+# ─── Verdict accuracy: score deltas without flips ────────────────────────────
+
+
+class TestScoreDeltasWithoutFlips:
+    def _score_delta_pair(self) -> tuple[EvalReport, EvalReport]:
+        # Both reports pass; scores moved but pass status didn't flip.
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("step", "Scorer", 0.85, True)],
+                )
+            ]
+        )
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("step", "Scorer", 0.92, True)],
+                )
+            ]
+        )
+        return baseline, report
+
+    def test_verdict_says_no_regressions_not_no_change(self) -> None:
+        baseline, report = self._score_delta_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        # Score moved up but didn't flip pass status. We don't claim "no
+        # change" because the rollup table will show a non-zero Δ.
+        assert "✅ All scorers passing · no regressions vs main" in out
+        assert "no change vs main" not in out
+
+    def test_extras_footnote_lists_score_deltas(self) -> None:
+        baseline, report = self._score_delta_pair()
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        assert "_Plus: 1 score delta._" in out
+
+
+class TestExtrasFootnote:
+    def test_lists_newly_added_scorers(self) -> None:
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("step", "ExactMatch", 1.0, True)],
+                )
+            ]
+        )
+        # Same step, but a new scorer joins.
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[
+                        _step_entry("step", "ExactMatch", 1.0, True),
+                        _step_entry("step", "Regex", 1.0, True),
+                    ],
+                )
+            ]
+        )
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        assert "_Plus: 1 newly added._" in out
+
+    def test_lists_removed_scorers(self) -> None:
+        baseline = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[
+                        _step_entry("step", "ExactMatch", 1.0, True),
+                        _step_entry("step", "Regex", 1.0, True),
+                    ],
+                )
+            ]
+        )
+        report = _report(
+            runs=[
+                _run(
+                    run_id="r1",
+                    step_scores=[_step_entry("step", "ExactMatch", 1.0, True)],
+                )
+            ]
+        )
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        assert "_Plus: 1 removed._" in out
+
+    def test_no_footnote_when_categories_are_empty(self) -> None:
+        # The TestPassingNoChange fixture has no extras; the footnote should
+        # be absent.
+        run_steps = [_step_entry("extract", "ExactMatch", 0.94, True)]
+        baseline = _report(runs=[_run(run_id="r1", step_scores=run_steps)])
+        report = _report(runs=[_run(run_id="r1", step_scores=list(run_steps))])
+        out = render_pr_comment(
+            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+        )
+        assert "_Plus:" not in out
+
+
 # ─── Failing-but-not-regressed (warning) state ───────────────────────────────
 
 


### PR DESCRIPTION
Closes #36. First deliverable in the Phase 5 set; foundation for the GitHub Action template (#37) which will use this renderer.

## Summary

- Pure-Python `render_pr_comment()` function in `pipewise/ci/github_action.py` that turns an `EvalReport` (plus optional baseline) into sticky-comment markdown.
- Reuses `pipewise.runner.diff.compute_diff` for regression/improvement categorization — no duplicated diffing logic.
- 24 unit tests covering the three reference states from the issue spec (passing-no-change, passing-improvements, regressing) plus missing-baseline, run-level scorers, structural cross-cuts, and edge cases.
- `pyproject.toml`: per-file RUF001/RUF002 ignore for the CI module so the intentional `×` (multiplication sign) in "Scorer × Step" labels is allowed (matches typography in Braintrust/Codecov PR-comment bots).

## Format design (locked from #36)

```
<!-- pipewise-eval-report:{adapter_name} -->
## Pipewise eval report — {adapter_name}

{verdict_line}                                    ← ✅/⚠️/❌ + plain-English count

| Scorer × Step | Main | This PR | Δ |
| :--- | ---: | ---: | ---: |
{rows}

**Regressions:** {N} 🔴 · **Improvements:** {N} 🟢 · **Unchanged:** {N}

<details><summary><b>Newly failing checks ({N})</b></summary>
…
</details>

<details><summary>Full report ({n_runs} runs · dataset: {name})</summary>
…
</details>

<sub>Updated for `{short_sha}` · pipewise v{version}</sub>
```

Signed Δ values, 🟢/🔴 emoji as the color channel (GitHub strips inline color), em-dash placeholder for unchanged cells (visual quietness rule), right-aligned numeric columns via `---:`, sticky-comment marker keyed by adapter name.

## Verdict-line states

- **No baseline:** `🆕 N runs · P/T scorers passing · no baseline`
- **Regressions present:** `❌ N regression(s) · was passing on main, failing here`
- **Failing but not regressed:** `⚠️ N failing scorer(s) · no regressions vs main`
- **Improvements only:** `✅ All scorers passing · N improvement(s) 🟢`
- **No changes:** `✅ All scorers passing · no change vs main`

## Test plan

- [x] `uv run pytest tests/ci/` — 24/24 passing
- [x] `uv run pytest -q --ignore=tests/integration` — 365 passed, 1 skipped (no regressions)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy pipewise/` — clean

## Out of scope (next issues)

- Action template at `.github/actions/pipewise-eval/` that calls this renderer (#37)
- `docs/ci-integration.md` adopter walkthrough (#38)
- Validation gate via test PR to factspark-app (#39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)