### PR TITLE
Phase 5 #37: pipewise-eval composite GitHub Action

### DIFF
--- a/.github/actions/pipewise-eval/README.md
+++ b/.github/actions/pipewise-eval/README.md
@@ -1,0 +1,156 @@
+# `pipewise-eval` GitHub Action
+
+Posts a sticky PR comment showing eval results for a pipewise-evaluated pipeline, with a diff against a baseline from main when available.
+
+## What it does
+
+1. Reads a pre-built [`EvalReport`](../../../docs/schema.md) JSON for the current PR.
+2. Optionally diffs against a baseline `EvalReport` (typically the most recent report from `main`).
+3. Renders sticky-comment markdown via [`pipewise.ci.render_pr_comment`](../../../pipewise/ci/github_action.py).
+4. Finds the existing pipewise eval comment on the PR (matched by a hidden HTML marker keyed by adapter name) and updates it, or creates a new one if none exists.
+
+## Architectural pattern: artifact-input only
+
+This action does **not** run your pipeline. It expects you to produce the `EvalReport` JSON yourself in an upstream step — typically by running `pipewise eval` after your pipeline finishes — and pass the file path in. This separation keeps your pipeline's secrets (LLM API keys, etc.) out of pipewise's action surface and means the action works for any pipeline shape regardless of execution complexity.
+
+The two-step pattern in your CI:
+
+1. **Run your pipeline + run `pipewise eval`** in your own job. Upload the resulting `EvalReport` JSON as a workflow artifact.
+2. **Use this action** in a subsequent job. Download the artifact (and a baseline artifact from a separate `main`-branch workflow if you want diffs), then call this action with the paths.
+
+## Inputs
+
+| Name | Required | Default | Description |
+|---|---|---|---|
+| `report-path` | yes | — | Path to the `EvalReport` JSON for this PR. |
+| `baseline-report-path` | no | `''` | Path to the baseline `EvalReport` JSON. If omitted or the file is missing, the comment shows absolute values with no Δ column. |
+| `adapter-name` | yes | — | Adapter package name (e.g. `factspark_pipewise`). Also the sticky-comment marker key — multi-adapter repos get one comment per adapter. |
+| `github-token` | yes | — | Token with `pull-requests: write` permission. Default `GITHUB_TOKEN` is fine. |
+| `python-version` | no | `'3.11'` | Python version used to run the renderer. |
+
+## Minimal example workflow
+
+```yaml
+name: pipewise eval
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read  # required to download artifacts from other workflows
+
+jobs:
+  run-and-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run pipeline + pipewise eval
+        run: |
+          python -m my_pipeline.run --output runs/
+          pip install pipewise
+          pipewise eval \
+            --adapter my_pipeline_pipewise.adapter \
+            --dataset golden.jsonl \
+            --output report.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pipewise-report
+          path: report.json
+          retention-days: 7
+
+  comment-on-pr:
+    needs: run-and-eval
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pipewise-report
+          path: ./report
+
+      - name: Download baseline report from main
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: pipewise-baseline.yml
+          name: pipewise-baseline-my-pipeline
+          path: ./baseline
+          if_no_artifact_found: warn  # silent fallback if baseline is missing
+
+      - uses: isthatamullet/pipewise/.github/actions/pipewise-eval@main
+        with:
+          report-path: ./report/report.json
+          baseline-report-path: ./baseline/report.json
+          adapter-name: my_pipeline_pipewise
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+A separate workflow on `main` should produce the baseline artifact (use `actions/upload-artifact` with a long retention period to feed the `download-artifact` step above). See [`docs/ci-integration.md`](../../../docs/ci-integration.md) for the full baseline-artifact pattern.
+
+## How the sticky comment works
+
+The action embeds a hidden HTML marker `<!-- pipewise-eval-report:{adapter_name} -->` in the comment body. On every push, the action searches the PR's comments for that marker:
+
+- **Found:** the matching comment is edited in place.
+- **Not found:** a new comment is created.
+
+The `adapter-name` input keys the marker — this means a repo with multiple adapters gets one sticky comment per adapter, and they don't clobber each other. Just call the action once per adapter with a different `adapter-name` each time.
+
+## Multi-adapter example
+
+```yaml
+- uses: isthatamullet/pipewise/.github/actions/pipewise-eval@main
+  with:
+    report-path: ./report-fast.json
+    adapter-name: my_pipeline_fast
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+
+- uses: isthatamullet/pipewise/.github/actions/pipewise-eval@main
+  with:
+    report-path: ./report-detailed.json
+    adapter-name: my_pipeline_detailed
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Each call manages its own sticky comment.
+
+## Comment format
+
+See [`pipewise/ci/github_action.py`](../../../pipewise/ci/github_action.py) and the unit tests in [`tests/ci/test_github_action.py`](../../../tests/ci/test_github_action.py) for the full rendered shape. At a glance:
+
+```markdown
+<!-- pipewise-eval-report:factspark_pipewise -->
+## Pipewise eval report — factspark_pipewise
+
+✅ All scorers passing · 2 improvements 🟢
+
+| Scorer × Step | Main | This PR | Δ |
+| :--- | ---: | ---: | ---: |
+| `ExactMatch` × `extract` | 0.40 | 0.97 | +0.57 🟢 |
+| `LlmJudge` × `analyze` | 0.45 | 0.91 | +0.46 🟢 |
+| `Regex` × `format` | 1.00 | 1.00 | — |
+
+**Regressions:** 0 🔴 · **Improvements:** 2 🟢 · **Unchanged:** 1
+
+<details><summary>Full report (1 run · dataset: golden.jsonl)</summary>
+…
+</details>
+
+<sub>Updated for `a1b2c3d` · pipewise v0.0.2</sub>
+```
+
+## Troubleshooting
+
+- **Comment doesn't appear.** Check that the calling workflow has `pull-requests: write` permission and is running on a `pull_request` event.
+- **Comment isn't updating across pushes.** Each adapter must use a unique `adapter-name` — that's the marker key. If two action calls share the same name, the second will overwrite the first.
+- **Baseline not found / no Δ column.** Expected on the first PR for a new repo, after artifact retention expires, or when the upstream `download-artifact` step doesn't find a baseline. Verify the baseline artifact actually exists on `main`'s most recent build.
+
+## Versioning
+
+Pin the action to a tag (e.g. `@v0.0.2`) once pipewise tags a release including the action. Pre-release, pin to `@main` or a specific SHA.

--- a/.github/actions/pipewise-eval/action.yml
+++ b/.github/actions/pipewise-eval/action.yml
@@ -1,0 +1,113 @@
+name: 'pipewise-eval'
+description: 'Render a sticky PR comment from a pipewise EvalReport (with optional baseline diff vs main).'
+author: 'isthatamullet'
+branding:
+  icon: 'check-circle'
+  color: 'blue'
+
+inputs:
+  report-path:
+    description: |
+      Path to the EvalReport JSON for this PR's pipeline run. Typically
+      produced upstream by `pipewise eval` and uploaded as a workflow
+      artifact, then downloaded by the calling workflow before this step.
+    required: true
+  baseline-report-path:
+    description: |
+      Path to the baseline EvalReport JSON (typically the most recent
+      report from main). If the path is omitted OR the file does not
+      exist on disk, the rendered comment shows absolute values with no
+      Δ column. Silent fallback is intentional — baselines may be absent
+      on the first PR for a new repo or after artifact retention expires;
+      the action should still produce a useful comment.
+    required: false
+    default: ''
+  adapter-name:
+    description: |
+      Adapter package name (e.g. `factspark_pipewise`). Used as the
+      sticky-comment marker key so multi-adapter repos can post one
+      comment per adapter without clobbering. Also shown in the comment
+      header.
+    required: true
+  github-token:
+    description: |
+      A token with `pull-requests: write` permission. The default
+      `GITHUB_TOKEN` is sufficient for most cases. The token is used to
+      find an existing pipewise eval comment (matched by the sticky
+      marker) and create or update it.
+    required: true
+  python-version:
+    description: 'Python version used to run the renderer.'
+    required: false
+    default: '3.11'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install pipewise
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        ACTION_REF: ${{ github.action_ref }}
+      run: |
+        # Install pipewise from whichever ref the action was invoked at.
+        # `github.action_path` resolves to the action's own directory inside
+        # the checked-out repo; the package root is three levels up
+        # (.github/actions/pipewise-eval/ → repo root). Editable install
+        # works for both the in-repo self-test path AND the external-consumer
+        # path (where GitHub fetches the entire pipewise repo into a tmp
+        # location to invoke the action).
+        REPO_ROOT="$(cd "${ACTION_PATH}/../../.." && pwd)"
+        echo "Installing pipewise from ${REPO_ROOT} (action ref: ${ACTION_REF})"
+        python -m pip install --upgrade pip
+        python -m pip install -e "${REPO_ROOT}"
+
+    - name: Render PR comment markdown
+      shell: bash
+      env:
+        REPORT_PATH: ${{ inputs.report-path }}
+        BASELINE_PATH: ${{ inputs.baseline-report-path }}
+        ADAPTER_NAME: ${{ inputs.adapter-name }}
+        # Use the PR head SHA, not GITHUB_SHA — for `pull_request` events
+        # GITHUB_SHA points at the temporary merge commit, which isn't the
+        # commit the reviewer actually pushed.
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        SHORT_SHA="${HEAD_SHA:0:7}"
+        OUTPUT_PATH="${RUNNER_TEMP}/pipewise-comment.md"
+
+        args=(
+          --report "$REPORT_PATH"
+          --adapter-name "$ADAPTER_NAME"
+          --short-sha "$SHORT_SHA"
+          --output "$OUTPUT_PATH"
+        )
+        if [[ -n "$BASELINE_PATH" ]]; then
+          args+=(--baseline "$BASELINE_PATH")
+        fi
+
+        python -m pipewise.ci "${args[@]}"
+        echo "comment-path=${OUTPUT_PATH}" >> "$GITHUB_OUTPUT"
+      id: render
+
+    - name: Find existing pipewise eval comment
+      uses: peter-evans/find-comment@v3
+      id: find-comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: '<!-- pipewise-eval-report:${{ inputs.adapter-name }} -->'
+        token: ${{ inputs.github-token }}
+
+    - name: Create or update PR comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-path: ${{ steps.render.outputs.comment-path }}
+        edit-mode: replace
+        token: ${{ inputs.github-token }}

--- a/.github/actions/pipewise-eval/action.yml
+++ b/.github/actions/pipewise-eval/action.yml
@@ -49,23 +49,38 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install pipewise
+    - name: Install pipewise (in isolated venv)
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
         ACTION_REF: ${{ github.action_ref }}
       run: |
-        # Install pipewise from whichever ref the action was invoked at.
-        # `github.action_path` resolves to the action's own directory inside
-        # the checked-out repo; the package root is three levels up
-        # (.github/actions/pipewise-eval/ → repo root). Editable install
-        # works for both the in-repo self-test path AND the external-consumer
-        # path (where GitHub fetches the entire pipewise repo into a tmp
-        # location to invoke the action).
+        # Install into a venv under $RUNNER_TEMP rather than the runner's
+        # global Python. Two reasons:
+        #   1. Avoid clobbering pydantic / typer / etc. versions the rest
+        #      of the user's workflow might depend on (the runner's global
+        #      env is shared across all steps in the job).
+        #   2. When the action is called multiple times in the same job —
+        #      e.g., the multi-adapter pattern in the README — the second
+        #      and subsequent calls reuse the venv and skip the install
+        #      step entirely.
+        # `github.action_path` resolves to the action's own directory; the
+        # package root is three levels up (.github/actions/pipewise-eval/
+        # → repo root). Works for both in-repo self-test (action runs from
+        # the same repo it lives in) and external-consumer (GitHub fetches
+        # pipewise into a tmp location at action_ref to invoke the action).
         REPO_ROOT="$(cd "${ACTION_PATH}/../../.." && pwd)"
-        echo "Installing pipewise from ${REPO_ROOT} (action ref: ${ACTION_REF})"
-        python -m pip install --upgrade pip
-        python -m pip install -e "${REPO_ROOT}"
+        VENV="${RUNNER_TEMP}/pipewise-venv"
+
+        if [[ -x "${VENV}/bin/python" ]]; then
+          echo "Reusing existing pipewise venv at ${VENV}"
+        else
+          echo "Installing pipewise from ${REPO_ROOT} (action ref: ${ACTION_REF})"
+          python -m venv "${VENV}"
+          "${VENV}/bin/python" -m pip install --upgrade pip
+          "${VENV}/bin/python" -m pip install "${REPO_ROOT}"
+        fi
+        echo "PIPEWISE_PYTHON=${VENV}/bin/python" >> "$GITHUB_ENV"
 
     - name: Render PR comment markdown
       shell: bash
@@ -91,7 +106,7 @@ runs:
           args+=(--baseline "$BASELINE_PATH")
         fi
 
-        python -m pipewise.ci "${args[@]}"
+        "${PIPEWISE_PYTHON}" -m pipewise.ci "${args[@]}"
         echo "comment-path=${OUTPUT_PATH}" >> "$GITHUB_OUTPUT"
       id: render
 

--- a/pipewise/ci/__main__.py
+++ b/pipewise/ci/__main__.py
@@ -71,10 +71,22 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
 
+    if not args.report.is_file():
+        print(
+            f"error: --report path is not a file: {args.report}",
+            file=sys.stderr,
+        )
+        return 1
+
     report = EvalReport.model_validate_json(args.report.read_text(encoding="utf-8"))
 
+    # Baseline is optional. The "path is set but file is missing" case is
+    # treated as "no baseline" rather than an error — the action passes the
+    # download-artifact target path even when no artifact exists. `is_file()`
+    # also rejects directories, which `exists()` would silently accept and
+    # crash on at `read_text()` time with a less obvious traceback.
     baseline: EvalReport | None = None
-    if args.baseline is not None and args.baseline.exists():
+    if args.baseline is not None and args.baseline.is_file():
         baseline = EvalReport.model_validate_json(args.baseline.read_text(encoding="utf-8"))
 
     markdown = render_pr_comment(

--- a/pipewise/ci/__main__.py
+++ b/pipewise/ci/__main__.py
@@ -1,0 +1,93 @@
+"""CLI entry point for pipewise.ci — `python -m pipewise.ci`.
+
+Used by the pipewise-eval GitHub Action (`.github/actions/pipewise-eval/`)
+to render an `EvalReport` (plus optional baseline) into the sticky-comment
+markdown that gets posted on a PR. Kept as a tiny argparse wrapper around
+`render_pr_comment` so adapters and CI integrations don't need to write
+any Python — they just shell out to this entry point.
+
+The "shell out to a CLI" pattern is intentional: it keeps the action's
+shell-side logic minimal (one `python -m` invocation), keeps the Python
+side fully unit-testable, and avoids embedding Python inside YAML where
+quoting bugs hide.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from pipewise.ci import render_pr_comment
+from pipewise.core.report import EvalReport
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m pipewise.ci",
+        description=("Render a pipewise EvalReport as markdown for a GitHub PR comment."),
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        required=True,
+        help="Path to the EvalReport JSON for this PR's pipeline run.",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the baseline EvalReport JSON (typically the most recent "
+            "report from main). If the path is omitted OR the file does not "
+            "exist, the rendered comment shows absolute values with no Δ "
+            "column. Silent fallback is intentional — baseline artifacts may "
+            "be missing on the first PR for a new repo or after retention "
+            "expires; the action should still produce a useful comment."
+        ),
+    )
+    parser.add_argument(
+        "--adapter-name",
+        required=True,
+        help=(
+            "Adapter package name. Used as the sticky-comment marker key so "
+            "multi-adapter repos can post one comment per adapter."
+        ),
+    )
+    parser.add_argument(
+        "--short-sha",
+        required=True,
+        help="Short Git SHA of the commit this report was generated for.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path where the rendered markdown will be written (UTF-8).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    report = EvalReport.model_validate_json(args.report.read_text(encoding="utf-8"))
+
+    baseline: EvalReport | None = None
+    if args.baseline is not None and args.baseline.exists():
+        baseline = EvalReport.model_validate_json(args.baseline.read_text(encoding="utf-8"))
+
+    markdown = render_pr_comment(
+        report,
+        adapter_name=args.adapter_name,
+        short_sha=args.short_sha,
+        baseline=baseline,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(markdown, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -198,12 +198,18 @@ class TestCliInProcess:
         assert rc == 0
         assert output_path.exists()
 
-    def test_invalid_report_json_raises(self, tmp_path: Path) -> None:
+    def test_invalid_report_json_raises_validation_error(self, tmp_path: Path) -> None:
+        # Pydantic raises ValidationError for malformed JSON — that's the
+        # expected failure mode for a corrupt report. Pin the test to that
+        # specific exception so a future change that swallows it (e.g., adds
+        # a generic try/except) fails the test loudly.
+        from pydantic import ValidationError
+
         report_path = tmp_path / "report.json"
         report_path.write_text("not json", encoding="utf-8")
         output_path = tmp_path / "comment.md"
 
-        with pytest.raises(Exception):  # noqa: B017 — pydantic ValidationError or json.JSONDecodeError
+        with pytest.raises(ValidationError):
             cli_main(
                 [
                     "--report",
@@ -216,6 +222,62 @@ class TestCliInProcess:
                     str(output_path),
                 ]
             )
+
+    def test_missing_report_file_returns_nonzero_with_clean_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # CLIs shouldn't dump tracebacks for user-facing input errors —
+        # that's just confusing in CI logs. Verify the missing-file case
+        # gets a clean stderr message + non-zero exit.
+        missing_path = tmp_path / "does-not-exist.json"
+        output_path = tmp_path / "comment.md"
+
+        rc = cli_main(
+            [
+                "--report",
+                str(missing_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "is not a file" in captured.err
+        assert str(missing_path) in captured.err
+        assert not output_path.exists()
+
+    def test_baseline_pointing_to_directory_falls_back_silently(self, tmp_path: Path) -> None:
+        # `is_file()` rejects directories where `exists()` would accept.
+        # Verify a baseline path that happens to be a directory falls back
+        # to "no baseline" rather than crashing inside read_text().
+        report_path = tmp_path / "report.json"
+        baseline_dir = tmp_path / "baseline-dir"
+        baseline_dir.mkdir()
+        output_path = tmp_path / "comment.md"
+        _write_report(report_path, _build_report())
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--baseline",
+                str(baseline_dir),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 0
+        assert "no baseline" in output_path.read_text(encoding="utf-8")
 
 
 # ─── End-to-end via `python -m pipewise.ci` subprocess ───────────────────────

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -1,0 +1,307 @@
+"""Tests for `python -m pipewise.ci` (#37).
+
+The CLI is the entry point that the pipewise-eval GitHub Action invokes.
+These tests subprocess the same module-run invocation the action uses, so
+"the action calls render_pr_comment with the right args" is exercised end
+to end at the same boundary the YAML hits.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pipewise import (
+    EvalReport,
+    RunEvalResult,
+    ScoreResult,
+    StepScoreEntry,
+)
+from pipewise.ci.__main__ import main as cli_main
+
+NOW = datetime(2026, 4, 29, 12, 0, 0, tzinfo=UTC)
+
+
+def _build_report(
+    *,
+    run_id: str = "r1",
+    score: float = 1.0,
+    passed: bool = True,
+    dataset_name: str | None = "golden.jsonl",
+) -> EvalReport:
+    return EvalReport(
+        report_id="test",
+        generated_at=NOW,
+        pipewise_version="0.0.1",
+        dataset_name=dataset_name,
+        scorer_names=["ExactMatch"],
+        runs=[
+            RunEvalResult(
+                run_id=run_id,
+                pipeline_name="factspark",
+                adapter_name="factspark_pipewise",
+                adapter_version="0.0.1",
+                step_scores=[
+                    StepScoreEntry(
+                        step_id="step",
+                        scorer_name="ExactMatch",
+                        result=ScoreResult(score=score, passed=passed),
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def _write_report(path: Path, report: EvalReport) -> None:
+    path.write_text(report.model_dump_json(), encoding="utf-8")
+
+
+# ─── In-process tests via cli_main() ─────────────────────────────────────────
+
+
+class TestCliInProcess:
+    def test_writes_markdown_to_output_path(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "report.json"
+        output_path = tmp_path / "comment.md"
+        _write_report(report_path, _build_report())
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc1234",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 0
+        assert output_path.exists()
+        content = output_path.read_text(encoding="utf-8")
+        assert content.startswith("<!-- pipewise-eval-report:factspark -->")
+        assert "## Pipewise eval report — factspark" in content
+        assert "<sub>Updated for `abc1234`" in content
+
+    def test_no_baseline_path_renders_no_diff_comment(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "report.json"
+        output_path = tmp_path / "comment.md"
+        _write_report(report_path, _build_report())
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 0
+        content = output_path.read_text(encoding="utf-8")
+        assert "🆕" in content
+        assert "no baseline" in content
+
+    def test_baseline_present_on_disk_renders_diff_comment(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "report.json"
+        baseline_path = tmp_path / "baseline.json"
+        output_path = tmp_path / "comment.md"
+        _write_report(report_path, _build_report(score=0.97, passed=True))
+        _write_report(baseline_path, _build_report(score=0.40, passed=False))
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--baseline",
+                str(baseline_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 0
+        content = output_path.read_text(encoding="utf-8")
+        # Improvement: failed→passed.
+        assert "1 improvement" in content
+
+    def test_baseline_path_pointing_to_missing_file_falls_back_silently(
+        self, tmp_path: Path
+    ) -> None:
+        # Common operational scenario: the workflow's download-artifact step
+        # didn't find a baseline (first PR / expired retention) and writes
+        # nothing to the expected path. The action passes the path anyway;
+        # the CLI must NOT fail — it should treat the missing file as
+        # "no baseline" and still render a useful comment.
+        report_path = tmp_path / "report.json"
+        baseline_path = tmp_path / "does-not-exist.json"
+        output_path = tmp_path / "comment.md"
+        _write_report(report_path, _build_report())
+        assert not baseline_path.exists()
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--baseline",
+                str(baseline_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 0
+        content = output_path.read_text(encoding="utf-8")
+        assert "no baseline" in content
+
+    def test_creates_output_parent_directory_if_missing(self, tmp_path: Path) -> None:
+        # The action writes to $RUNNER_TEMP/pipewise-comment.md which exists,
+        # but defensive handling of nested paths matters for non-CI usage.
+        report_path = tmp_path / "report.json"
+        output_path = tmp_path / "nested" / "subdir" / "comment.md"
+        _write_report(report_path, _build_report())
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+
+        assert rc == 0
+        assert output_path.exists()
+
+    def test_invalid_report_json_raises(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "report.json"
+        report_path.write_text("not json", encoding="utf-8")
+        output_path = tmp_path / "comment.md"
+
+        with pytest.raises(Exception):  # noqa: B017 — pydantic ValidationError or json.JSONDecodeError
+            cli_main(
+                [
+                    "--report",
+                    str(report_path),
+                    "--adapter-name",
+                    "factspark",
+                    "--short-sha",
+                    "abc",
+                    "--output",
+                    str(output_path),
+                ]
+            )
+
+
+# ─── End-to-end via `python -m pipewise.ci` subprocess ───────────────────────
+
+
+class TestCliSubprocess:
+    """Exercise the same invocation path the GitHub Action uses.
+
+    The action's YAML runs `python -m pipewise.ci ...`. Subprocessing here
+    catches breakage in the `__main__` plumbing that in-process `main()`
+    calls would miss (missing `if __name__` guard, broken imports under
+    `-m`, etc.).
+    """
+
+    def test_module_run_produces_expected_markdown(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "report.json"
+        output_path = tmp_path / "comment.md"
+        _write_report(report_path, _build_report())
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pipewise.ci",
+                "--report",
+                str(report_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "deadbee",
+                "--output",
+                str(output_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        content = output_path.read_text(encoding="utf-8")
+        assert content.startswith("<!-- pipewise-eval-report:factspark -->")
+        assert "<sub>Updated for `deadbee`" in content
+
+    def test_module_run_help_flag_succeeds(self) -> None:
+        # If the `python -m` plumbing is broken, even --help fails.
+        result = subprocess.run(
+            [sys.executable, "-m", "pipewise.ci", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert "Render a pipewise EvalReport" in result.stdout
+
+
+# ─── Ensure round-trip via model_dump_json works ─────────────────────────────
+
+
+class TestReportRoundTrip:
+    """Pipewise.runner.storage produces report JSON via `model_dump_json`.
+    The CLI must accept that exact serialization. Sanity check the round-
+    trip rather than rely on hand-written JSON to stay in sync with the
+    schema.
+    """
+
+    def test_round_trip_via_model_dump_json(self, tmp_path: Path) -> None:
+        report = _build_report()
+        serialized = report.model_dump_json()
+        # Sanity: confirm it parses as JSON before writing.
+        parsed: dict[str, Any] = json.loads(serialized)
+        assert "runs" in parsed
+
+        report_path = tmp_path / "report.json"
+        report_path.write_text(serialized, encoding="utf-8")
+        output_path = tmp_path / "comment.md"
+
+        rc = cli_main(
+            [
+                "--report",
+                str(report_path),
+                "--adapter-name",
+                "factspark",
+                "--short-sha",
+                "abc",
+                "--output",
+                str(output_path),
+            ]
+        )
+        assert rc == 0


### PR DESCRIPTION
Closes #37. Builds on #36 (renderer) — this PR wraps it in a reusable composite action + Python CLI entry point.

## Summary

- `.github/actions/pipewise-eval/action.yml` — composite action: setup-python → install pipewise → render markdown → find existing sticky comment → create-or-update.
- `pipewise/ci/__main__.py` — argparse CLI for `python -m pipewise.ci`. The action invokes this rather than embedding Python in YAML.
- `.github/actions/pipewise-eval/README.md` — usage docs with a complete example workflow, multi-adapter pattern, troubleshooting.
- `tests/ci/test_cli.py` — 9 tests (in-process + subprocess `python -m`).

## Architectural decisions (locked from #37)

- **Artifact-input only.** Action takes pre-built `EvalReport` JSON paths; never runs `pipewise eval` itself. Preserves the "EVALUATES, doesn't EXECUTE" non-negotiable and keeps adapter secrets (LLM API keys, etc.) out of the action's surface.
- **Sticky comment via hidden HTML marker keyed by `adapter-name`.** Multi-adapter repos call the action once per adapter; each gets its own sticky comment without clobbering.
- **Silent fallback on missing baseline.** When `baseline-report-path` is unset OR the file is missing on disk (common case: first PR, expired retention, download-artifact didn't find anything), the comment renders with absolute values and no Δ column instead of failing.
- **`pip install -e <repo-root>` from `${{ github.action_path }}/../../..`.** Works for both the in-repo self-test path and the external-consumer path where GitHub fetches the entire pipewise repo into a tmp location.
- **PR head SHA, not GITHUB_SHA.** For `pull_request` events `GITHUB_SHA` points at the temp merge commit; the comment footer uses the PR head SHA so the staleness verification matches what the reviewer pushed.

## Inputs

| Name | Required | Default | Description |
|---|---|---|---|
| `report-path` | yes | — | Path to the EvalReport JSON for this PR. |
| `baseline-report-path` | no | `''` | Baseline EvalReport JSON path. Silent fallback when unset/missing. |
| `adapter-name` | yes | — | Adapter package name. Also the sticky-comment marker key. |
| `github-token` | yes | — | Token with `pull-requests: write`. Default `GITHUB_TOKEN` works. |
| `python-version` | no | `'3.11'` | Python version for the renderer. |

## Test plan

- [x] `uv run pytest tests/ci/` — 39/39 passing (30 from #36 + 9 new CLI tests)
- [x] `uv run pytest -q --ignore=tests/integration` — 380 passed, 1 skipped (no regressions)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy pipewise/` — clean

The CLI tests subprocess `python -m pipewise.ci` so the action's invocation path is exercised end to end at the YAML→Python boundary. Catches breakage in `__main__` plumbing that in-process `main()` calls would miss.

## Deferred to #39 (validation gate)

The composite action itself (peter-evans/find-comment + create-or-update-comment integration) is best validated by actually running it on a real PR. That happens in #39 — the validation gate where this action gets wired into factspark-app's CI.

## Out of scope (next issues)

- `docs/ci-integration.md` adopter walkthrough (#38)
- Validation gate via test PR to factspark-app (#39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)