### PR TITLE
Phase 5 #38: docs/ci-integration.md adopter walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Evaluation framework for multi-step LLM pipelines.**
 
-> **Status:** Phase 3 shipped — the CLI (`pipewise eval`, `inspect`, `diff`) works end-to-end against real pipeline data, with 8 built-in scorers and 350+ tests passing. Phase 4 (reference adapters) is in progress; v1.0 target is 6-8 weeks. Schema and CLI surfaces are not yet frozen — pin your install until v1.0. Star/watch to follow progress.
+> **Status:** Phase 4 shipped (reference adapters validate the abstraction across both linear and branching pipeline shapes; v0.0.1 tagged). Phase 5 (CI integration — GitHub Action that posts eval reports as sticky PR comments) is in progress, with 380+ tests passing. v1.0 target is 4-6 weeks. Schema and CLI surfaces are not yet frozen — pin your install until v1.0. Star/watch to follow progress.
 
 [![CI](https://github.com/isthatamullet/pipewise/actions/workflows/ci.yml/badge.svg)](https://github.com/isthatamullet/pipewise/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
@@ -149,6 +149,8 @@ Full adapter links land here once Phase 4 ships.
 
 - [**Schema reference**](docs/schema.md) — `PipelineRun`, `StepExecution`, `ScoreResult`, `EvalReport`. Read this first if you're writing an adapter.
 - [**Adapter guide**](docs/adapter-guide.md) — how to integrate your own pipeline.
+- [**Scorer reference**](docs/scorers.md) — the 8 built-in scorers and how to choose between them.
+- [**CI integration**](docs/ci-integration.md) — wire pipewise into your CI to post a sticky eval-report comment on every PR.
 
 ## Roadmap
 
@@ -158,8 +160,8 @@ Full adapter links land here once Phase 4 ships.
 | 1 | `PipelineRun` + `StepExecution` schemas, scorer protocols | ✅ Shipped |
 | 2 | 8 built-in scorers (exact match, regex, numeric tolerance, JSON schema, cost / latency budgets, LLM judge, embedding similarity) | ✅ Shipped |
 | 3 | `pipewise inspect`, `pipewise eval`, `pipewise diff` CLI | ✅ Shipped |
-| 4 | FactSpark + resume-tailor reference adapters | In progress |
-| 5 | GitHub Action for PR-comment eval reports | Upcoming |
+| 4 | FactSpark + resume-tailor reference adapters | ✅ Shipped |
+| 5 | GitHub Action for PR-comment eval reports | In progress |
 | 6 | Polish + v1.0 launch | Upcoming |
 
 Each phase ships incrementally to `main` with tests and CI, with reference-pipeline validation gates at the end of every architectural phase.

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -81,7 +81,8 @@ jobs:
           # Your pipeline's secrets — only this job sees them.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          pip install pipewise
+          # Pre-v1.0 / pre-PyPI install — pin to a SHA or tag in CI.
+          pip install git+https://github.com/isthatamullet/pipewise.git@main
           # 1. Run your pipeline against the canonical dataset.
           python -m my_pipeline.run --dataset golden.jsonl --output runs/
 
@@ -108,7 +109,7 @@ jobs:
           path: ./report
 
       - name: Download baseline report from main
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v8
         with:
           workflow: pipewise-baseline.yml
           name: pipewise-baseline-my-pipeline
@@ -122,6 +123,8 @@ jobs:
           adapter-name: my_pipeline_pipewise
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+> **Pin the action and pipewise install in production CI.** Both examples above use `@main` for readability, but main can move under your feet — a breaking change merged upstream would silently flow into your CI. Pin both `pipewise/.github/actions/pipewise-eval@<sha-or-tag>` and `git+https://...@<sha-or-tag>` to a specific commit SHA pre-v1.0, then switch to a release tag once v1.0 ships.
 
 A few details worth understanding:
 
@@ -157,7 +160,8 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          pip install pipewise
+          # Pre-v1.0 / pre-PyPI install — pin to a SHA or tag in CI.
+          pip install git+https://github.com/isthatamullet/pipewise.git@main
           python -m my_pipeline.run --dataset golden.jsonl --output runs/
           pipewise eval \
             --adapter my_pipeline_pipewise.adapter \
@@ -281,7 +285,15 @@ Until pipewise v1.0 ships, the FactSpark adapter and pipeline live in `factspark
 
 ### Action fails on `pip install pipewise`
 
-- Pre-v1.0, pipewise isn't on PyPI yet. The action installs from source (the same ref it was invoked at) — see [the action's `Install pipewise` step](../.github/actions/pipewise-eval/action.yml). Pin the action to `@main` or a specific SHA pre-v1.0; a release-tag pin will be available once v1.0 ships.
+- Pre-v1.0, pipewise isn't on PyPI yet. Use `pip install git+https://github.com/isthatamullet/pipewise.git@<ref>` instead, where `<ref>` is `main`, a tag, or a specific commit SHA. The action itself installs pipewise the same way internally — see [its `Install pipewise` step](../.github/actions/pipewise-eval/action.yml).
+- Pin the action to a specific commit SHA pre-v1.0 (browse [recent commits](https://github.com/isthatamullet/pipewise/commits/main) for one); switch to a release tag once one exists that includes the action.
+
+### Comment doesn't appear on PRs from forks
+
+- For PRs opened from a fork, GitHub restricts the default `GITHUB_TOKEN` to read-only scopes — the action's `find-comment` and `create-or-update-comment` calls will fail with permission errors. Two ways to handle it:
+  - **`pull_request_target` event** — runs the workflow with full write tokens against the base branch's code. ⚠️ Security caveat: never check out the fork's code in this workflow without careful sandboxing; a malicious fork could steal secrets. Safe pattern: keep the run-and-eval job on `pull_request` (read-only) and the comment-on-pr job on `pull_request_target` reading the artifact produced by the run-and-eval job.
+  - **`workflow_run` event** — runs after the PR's CI completes, has full write access. More complex to wire (requires looking up the original PR number from the workflow run context) but is the conservative default for public repos.
+- Internal-only repos (no fork PRs) can ignore this — the default `GITHUB_TOKEN` has write access for non-fork PRs.
 
 ---
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -1,0 +1,292 @@
+# CI integration
+
+How to wire pipewise into your repo's CI so every PR gets an eval report posted as a sticky comment, with a diff against `main` when one's available.
+
+> **Status:** Phase 5 (the GitHub Action + this guide) is in flight. The action itself is at [`.github/actions/pipewise-eval/`](../.github/actions/pipewise-eval/) and is usable now; pin to a SHA pre-v1.0 and to a release tag once v1.0 ships.
+
+---
+
+## What you get
+
+A single sticky comment per adapter on every PR, updated in place across pushes:
+
+```markdown
+<!-- pipewise-eval-report:factspark_pipewise -->
+## Pipewise eval report — factspark_pipewise
+
+✅ All scorers passing · 2 improvements 🟢
+
+| Scorer × Step | Main | This PR | Δ |
+| :--- | ---: | ---: | ---: |
+| `ExactMatch` × `extract` | 0.40 | 0.97 | +0.57 🟢 |
+| `LlmJudge` × `analyze` | 0.45 | 0.91 | +0.46 🟢 |
+| `Regex` × `format` | 1.00 | 1.00 | — |
+
+**Regressions:** 0 🔴 · **Improvements:** 2 🟢 · **Unchanged:** 1
+
+<details><summary>Full report (1 run · dataset: golden.jsonl)</summary>
+…
+</details>
+
+<sub>Updated for `a1b2c3d` · pipewise v0.0.2</sub>
+```
+
+The verdict line is the most prominent element — reviewers can tell at a glance whether the PR is safe (`✅`), warning (`⚠️`), or breaking (`❌`). The `Δ` column shows signed deltas vs `main` with 🟢/🔴 emoji as the color channel (GitHub markdown strips inline color). Newly-failing checks expand into a `<details>` block with the specific case + scorer + reason. The full per-case table lives in another `<details>` block — collapsed by default so the comment stays scannable.
+
+---
+
+## The two-step CI pattern
+
+Pipewise [evaluates, it does not execute](../README.md#what-it-is-not) — and the GitHub Action follows the same separation. The action does NOT run your pipeline. Your CI does that, then hands pipewise a pre-built `EvalReport` JSON to render.
+
+**Step 1 — your CI:** run your pipeline against a small canonical dataset, run `pipewise eval` against the resulting runs, upload the `EvalReport` as a workflow artifact.
+
+**Step 2 — `pipewise-eval` action:** download the artifact (and a baseline `EvalReport` from a separate `main`-branch workflow), call the action, get a sticky comment.
+
+Why split:
+
+- **Your pipeline's secrets stay yours.** Your LLM API keys, vendor tokens, etc. live in the run-and-eval job. The pipewise action only needs `pull-requests: write` — no secret handling on the comment side.
+- **Pipewise stays adapter-shape-agnostic.** Any pipeline that produces an `EvalReport` (one of [the JSON shape pipewise defines](schema.md)) gets a comment. The action doesn't care whether your pipeline is LangChain, raw Anthropic SDK, a shell script, or all three glued together.
+- **You get a clean cache story.** `pipewise eval` produces an immutable timestamped report; the artifact upload preserves it; subsequent steps just read it.
+
+---
+
+## Minimal example workflow
+
+A complete, copy-pasteable `.github/workflows/pipewise-eval.yml` for an adopter's repo:
+
+```yaml
+name: pipewise eval
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read  # required for cross-workflow artifact downloads
+
+jobs:
+  run-and-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run pipeline + pipewise eval
+        env:
+          # Your pipeline's secrets — only this job sees them.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          pip install pipewise
+          # 1. Run your pipeline against the canonical dataset.
+          python -m my_pipeline.run --dataset golden.jsonl --output runs/
+
+          # 2. Run pipewise eval on the produced runs.
+          pipewise eval \
+            --adapter my_pipeline_pipewise.adapter \
+            --dataset golden.jsonl \
+            --output report.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pipewise-report
+          path: report.json
+          retention-days: 7
+
+  comment-on-pr:
+    needs: run-and-eval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download this PR's report
+        uses: actions/download-artifact@v4
+        with:
+          name: pipewise-report
+          path: ./report
+
+      - name: Download baseline report from main
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: pipewise-baseline.yml
+          name: pipewise-baseline-my-pipeline
+          path: ./baseline
+          if_no_artifact_found: warn  # silent fallback when none exists yet
+
+      - uses: isthatamullet/pipewise/.github/actions/pipewise-eval@main
+        with:
+          report-path: ./report/report.json
+          baseline-report-path: ./baseline/report.json
+          adapter-name: my_pipeline_pipewise
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+A few details worth understanding:
+
+- **`needs: run-and-eval`** sequences the comment job after the eval job. They're separate jobs (not steps in one job) so the second one can stay tightly scoped — checkout-free, secret-free.
+- **`actions: read` permission** is required by the cross-workflow artifact download. Without it, `dawidd6/action-download-artifact` can't reach the baseline workflow's artifact.
+- **`if_no_artifact_found: warn`** is the right setting for the baseline. If there's no baseline yet (first PR on a new repo, retention expired, baseline workflow hasn't run yet), the comment job continues without a baseline and the action renders an absolute-values comment with no `Δ` column — see the [silent baseline fallback](#silent-baseline-fallback) section below.
+
+---
+
+## Baseline strategy
+
+The action diffs your PR's report against a "baseline" report from `main`. You produce that baseline yourself, in a separate workflow that runs on every push to `main`:
+
+```yaml
+# .github/workflows/pipewise-baseline.yml
+name: pipewise baseline
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  produce-baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run pipeline + pipewise eval
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          pip install pipewise
+          python -m my_pipeline.run --dataset golden.jsonl --output runs/
+          pipewise eval \
+            --adapter my_pipeline_pipewise.adapter \
+            --dataset golden.jsonl \
+            --output report.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pipewise-baseline-my-pipeline
+          path: report.json
+          retention-days: 90  # long enough that long-lived PRs find it
+```
+
+**Naming convention.** `pipewise-baseline-<adapter>` lets a multi-adapter repo carry parallel baselines. The PR-side `download-artifact` step references the matching name.
+
+**Retention.** Default GitHub artifact retention is 90 days; that's the right ceiling for the baseline. PRs that sit open longer than that lose their baseline and revert to absolute-values comments — usually a signal the PR is stale and worth force-pushing anyway.
+
+**Determinism.** A baseline that re-runs the pipeline produces fresh `LlmJudge` calls, fresh latency, fresh costs. If your scorers are stable across runs (deterministic models, fixed temperatures, etc.) the baseline is meaningful. If they're not, the comment will show spurious `Δ`s; that's a correctness signal you may want to address by tightening determinism in the pipeline itself rather than papering over in pipewise.
+
+---
+
+## Silent baseline fallback
+
+If the `baseline-report-path` input is unset, OR the path is set but no file exists at it, the action renders the comment with absolute values and no `Δ` column. The verdict line in that case is:
+
+```
+🆕 N runs · P/T scorers passing · no baseline
+```
+
+Common operational scenarios where this kicks in:
+
+- First PR on a new repo (baseline workflow hasn't run yet)
+- The baseline workflow failed on the most recent `main` push, so no artifact exists
+- Artifact retention expired
+- The PR was opened from a fork without access to the baseline artifact
+
+In all of these, the action *still* posts a useful comment showing what your PR's eval looks like in absolute terms. No silent failure.
+
+---
+
+## Multi-adapter repos
+
+Each call to the action posts its own sticky comment, keyed by `adapter-name`. A repo with multiple adapters just calls the action multiple times:
+
+```yaml
+- uses: isthatamullet/pipewise/.github/actions/pipewise-eval@main
+  with:
+    report-path: ./report-fast/report.json
+    baseline-report-path: ./baseline-fast/report.json
+    adapter-name: my_pipeline_fast
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+
+- uses: isthatamullet/pipewise/.github/actions/pipewise-eval@main
+  with:
+    report-path: ./report-detailed/report.json
+    baseline-report-path: ./baseline-detailed/report.json
+    adapter-name: my_pipeline_detailed
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Two sticky comments will appear on the PR, one per adapter, each updated in place on every push. The hidden HTML marker in the comment body is `<!-- pipewise-eval-report:{adapter-name} -->`, so as long as `adapter-name` is unique per call, the comments stay independent.
+
+The action also reuses a single Python venv across calls in the same job — see [the action's README](../.github/actions/pipewise-eval/README.md) for the implementation detail.
+
+---
+
+## Comment format walkthrough
+
+The comment is rendered by [`pipewise.ci.render_pr_comment()`](../pipewise/ci/github_action.py). The structure is:
+
+| Section | Purpose |
+|---|---|
+| **Sticky marker** (HTML comment, line 1) | Hidden token keyed by adapter name. The action uses it to find-and-update the existing comment. |
+| **H2 header** | Identifies the report at a glance — `## Pipewise eval report — {adapter_name}`. |
+| **Verdict line** | Most prominent element. Single line with emoji + plain-English summary: `✅ All scorers passing · no change vs main` / `❌ N regressions` / `🆕 N runs · no baseline`. |
+| **Roll-up table** | One row per `(scorer, step)` combination. Numeric columns right-aligned; `Δ` column shows signed deltas with 🟢/🔴 emoji or `—` for no change. Em-dash placeholder is used for "unchanged" so the eye skips over noise. |
+| **Counts row** | `**Regressions:** N 🔴 · **Improvements:** N 🟢 · **Unchanged:** N`. Reservation: regressions/improvements are strict pass/fail flips, not score-only deltas. |
+| **Extras footnote** *(when relevant)* | `_Plus: N score deltas, M newly added, K removed._` — only renders when those categories are non-empty. Keeps the clean common case clean. |
+| **Newly-failing checks** *(when relevant)* | Collapsible `<details>` listing each scorer that flipped passing → failing, with the specific case ID and reason. |
+| **Full report** | Collapsible `<details>` with the per-case table — every `(run, step, scorer)` combination. |
+| **Footer** | `<sub>Updated for {short_sha} · pipewise v{version}</sub>` — short SHA lets reviewers verify the comment matches the latest push. |
+
+For the full set of states the renderer handles (passing-no-change, passing-improvements, regressing, missing-baseline, score-deltas-without-flips, etc.), see the [renderer's unit tests](../tests/ci/test_github_action.py).
+
+---
+
+## Worked example: FactSpark
+
+FactSpark is one of pipewise's two reference adapter integrations. Its CI integration follows the pattern documented above, with a few specifics:
+
+- **Canonical dataset:** ~3 articles from `factspark-app/articles/canonical/` (a fixed set chosen to exercise different pipeline branches).
+- **Adapter name:** `factspark_pipewise`.
+- **Baseline retention:** 90 days.
+- **Validation gate:** the [Phase 5 #39 validation gate](https://github.com/isthatamullet/pipewise/issues/39) wires this pattern into factspark-app and is the end-to-end proof that the pattern works against a real production pipeline.
+
+Until pipewise v1.0 ships, the FactSpark adapter and pipeline live in `factspark-app/integrations/pipewise/` (private repo). Once both go public alongside v1.0, the worked example above will be upgraded to live links pointing at the public repos. *(See [Phase 6 prep: public mirror repos for reference adapters](https://github.com/isthatamullet/pipewise/issues/35) for the plan.)*
+
+---
+
+## Troubleshooting
+
+### Comment doesn't appear
+
+- The calling workflow needs `pull-requests: write` permission. Add it under `permissions:` at the workflow or job level.
+- The workflow must run on a `pull_request` event (or a related event with `pull_request` context). The action uses `github.event.pull_request.number` to identify the target PR.
+- Check the action's logs in the workflow run — if the `Find existing pipewise eval comment` step shows an auth error, the `github-token` input doesn't have the right scope.
+
+### Comment isn't updating across pushes
+
+- Each call must use a unique `adapter-name`. That's the marker key. Two calls with the same name will overwrite each other's comments.
+- If you renamed the adapter mid-PR, the action will create a new comment under the new name and orphan the old one. Either keep the name stable or accept the orphan.
+
+### Δ column is missing
+
+- Expected when no baseline is provided. See [Silent baseline fallback](#silent-baseline-fallback).
+- If you DID provide a baseline-report-path but the column is still missing, verify the file actually exists at that path in the runner — the action treats missing files as "no baseline" rather than failing. Check the `Render PR comment markdown` step's logs.
+
+### Comment shows spurious `Δ`s on every push
+
+- Your scorers aren't deterministic. `LlmJudgeScorer` calls produce different results across runs unless you've pinned model temperature, used `consensus_n` aggressively, or are evaluating on cached outputs. The fix is in your pipeline / scorer config, not pipewise.
+
+### Action fails on `pip install pipewise`
+
+- Pre-v1.0, pipewise isn't on PyPI yet. The action installs from source (the same ref it was invoked at) — see [the action's `Install pipewise` step](../.github/actions/pipewise-eval/action.yml). Pin the action to `@main` or a specific SHA pre-v1.0; a release-tag pin will be available once v1.0 ships.
+
+---
+
+## Related docs
+
+- [Schema reference](schema.md) — the `EvalReport` JSON shape your CI is producing.
+- [Adapter guide](adapter-guide.md) — how to write the adapter that the run-and-eval job uses.
+- [Action README](../.github/actions/pipewise-eval/README.md) — the action's input/output reference.


### PR DESCRIPTION
Closes #38. Walkthrough for adopters wiring pipewise into their CI; depends on #36 (renderer) and #37 (action), both merged.

## Summary

- New `docs/ci-integration.md` — 9 sections covering the two-step CI pattern, minimal example workflow, baseline strategy, silent fallback, multi-adapter repos, comment-format walkthrough, FactSpark worked example, troubleshooting.
- Linked from README's Documentation section.
- Piggybacked: README status update (Phase 3 → Phase 4 shipped; Phase 5 in progress) since the README was stale from the prior session arc.

## Coverage

All 7 sections from the issue spec, plus 2 added during writing (silent baseline fallback section split out for visibility; FactSpark worked example as its own section instead of inlined).

| § | Issue spec | Doc section |
|---|---|---|
| 1 | What you get | ✅ `## What you get` (with sample comment markdown) |
| 2 | Two-step CI pattern | ✅ `## The two-step CI pattern` |
| 3 | Minimal example workflow YAML | ✅ `## Minimal example workflow` |
| 4 | Baseline strategy | ✅ `## Baseline strategy` (separate `pipewise-baseline.yml` workflow + retention guidance + multi-adapter naming) |
| 5 | Comment format walkthrough | ✅ `## Comment format walkthrough` (table mapping each section of the rendered comment to its purpose) |
| 6 | Multi-adapter repos | ✅ `## Multi-adapter repos` (pattern + cross-link to venv reuse in action) |
| 7 | Troubleshooting / FAQ | ✅ `## Troubleshooting` (5 common scenarios) |

Plus:
- `## Silent baseline fallback` — explicit section for the operational case (first PR, expired retention, fork PR)
- `## Worked example: FactSpark` — plain-text repo refs per `feedback-private-repo-links.md`; will upgrade to live links during the Phase 6 mirror-repo work in #35

## Cross-links

- `docs/schema.md` — for the EvalReport JSON shape adopters' CI is producing
- `docs/adapter-guide.md` — where adapters are introduced
- `.github/actions/pipewise-eval/README.md` — input/output reference for the action itself
- `pipewise/ci/github_action.py` + `tests/ci/test_github_action.py` — renderer source + canonical state-by-state reference
- `#35` — Phase 6 mirror-repo plan (forward-ref for "live links land alongside v1.0")
- `#39` — Phase 5 validation gate (forward-ref for "real production proof")

## README piggyback

- Status line refreshed: Phase 4 shipped (was "in progress"), Phase 5 in progress (was "upcoming"), v1.0 ETA 4-6 weeks (was 6-8).
- Roadmap table: Phase 4 ✅ Shipped; Phase 5 In progress.
- Documentation section: added `ci-integration.md` link + `scorers.md` link (the latter was missing entirely).

## Test plan

- [x] `uv run pytest -q --ignore=tests/integration` — 382 passed, 1 skipped (no regressions; doc-only PR but verified)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] Manual: read through the doc end-to-end. Worked example uses plain-text repo refs only. Cross-links resolve. Code blocks are copy-paste-runnable.

## Out of scope (next issue)

- Validation gate via test PR to factspark-app (#39) — the end-to-end proof that the documented pattern actually works against a real production pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)