### PR TITLE
Phase 6: CHANGELOG.md [Unreleased] update for Phase 5 + initial Phase 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ Until v1.0, **minor and patch versions may include breaking changes** — pipewi
 
 ## [Unreleased]
 
-_Phase 5 — GitHub Action for PR-comment eval reports — in progress._
+### Added
+
+- **`pipewise.ci.github_action.render_pr_comment()`** — pure-Python renderer that produces a sticky-comment markdown body from an `EvalReport` (and optional baseline). Reuses `pipewise.runner.diff.compute_diff` rather than reinventing diffing. Output includes a verdict line (`✅` / `⚠️` / `❌` / `🆕`), scorer × step rollup table with right-aligned numeric columns and a signed Δ column, newly-failing-checks `<details>` block when regressions exist, full per-case `<details>`, and a footer with the short SHA + pipewise version. (#40)
+- **`pipewise.ci.__main__`** — CLI entry point invoked via `python -m pipewise.ci`. Renders a PR-comment markdown body from `--report <path>` (and optional `--baseline <path>`) and writes it to `--output <path>`. This is the invocation boundary the `pipewise-eval` GitHub Action shells out to. (#40, #41)
+- **`pipewise-eval` composite GitHub Action** at `.github/actions/pipewise-eval/` — reusable workflow step that consumes a pre-built `EvalReport` JSON artifact, renders it via `python -m pipewise.ci`, and posts/updates a sticky PR comment keyed by adapter name. Artifact-input-only by design (preserves the EVALUATES-not-EXECUTES non-negotiable). Multi-adapter repos call it once per adapter; each adapter gets its own sticky comment. Silent fallback to absolute values when the baseline artifact is missing. Installs pipewise into an isolated venv at `${RUNNER_TEMP}/pipewise-venv` to avoid clobbering the user's workflow Python environment. (#41)
+- **`docs/ci-integration.md`** — adopter walkthrough for wiring `pipewise-eval` into a repository's CI. Covers the two-step pattern (eval → comment), baseline strategy with long-retention artifacts, multi-adapter support, comment-format walkthrough, a worked example using FactSpark, and a troubleshooting section including the `dawidd6/action-download-artifact` `continue-on-error` requirement and the `git revert`-on-single-commit-PR path-filter edge case. (#42, #43, #44)
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, drop-in template with `hello@pipewise.dev` as the enforcement contact. (#46)
+- **`SECURITY.md`** — vulnerability reporting policy. Leads with GitHub Security Advisories as the preferred private channel; email fallback to `security@pipewise.dev`. Pre-1.0 supported-versions stance, best-effort response timeline (acknowledgment within 2 business days, initial assessment within 5), brief coordinated-disclosure process, and an explicit out-of-scope section. (#48)
+
+### Changed
+
+- **`README.md`** — Phase 5 status updated to shipped; documentation index now links to `docs/scorers.md` and `docs/ci-integration.md`; Contributing section now links to `CODE_OF_CONDUCT.md`. (#42, #46)
+- **`CONTRIBUTING.md`** — Code of Conduct section migrated from an inline paragraph to a link to the formal `CODE_OF_CONDUCT.md`; reporting contact updated to `hello@pipewise.dev`. (#46)
+- **`pyproject.toml`** — author email migrated from the maintainer's personal gmail to project-bounded `hello@pipewise.dev` (Workspace alias). Affects published PyPI metadata when pipewise releases. (#46)
 
 ## [0.0.1] — 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Until v1.0, **minor and patch versions may include breaking changes** — pipewi
 
 ### Changed
 
-- **`README.md`** — Phase 5 status updated to shipped; documentation index now links to `docs/scorers.md` and `docs/ci-integration.md`; Contributing section now links to `CODE_OF_CONDUCT.md`. (#42, #46)
+- **`README.md`** — Phase 5 status updated to shipped (status banner + roadmap table) (#50); documentation index now links to `docs/scorers.md` and `docs/ci-integration.md` (#42); Contributing section now links to `CODE_OF_CONDUCT.md` (#46).
 - **`CONTRIBUTING.md`** — Code of Conduct section migrated from an inline paragraph to a link to the formal `CODE_OF_CONDUCT.md`; reporting contact updated to `hello@pipewise.dev`. (#46)
 - **`pyproject.toml`** — author email migrated from the maintainer's personal gmail to project-bounded `hello@pipewise.dev` (Workspace alias). Affects published PyPI metadata when pipewise releases. (#46)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Evaluation framework for multi-step LLM pipelines.**
 
-> **Status:** Phase 4 shipped (reference adapters validate the abstraction across both linear and branching pipeline shapes; v0.0.1 tagged). Phase 5 (CI integration — GitHub Action that posts eval reports as sticky PR comments) is in progress, with 380+ tests passing. v1.0 target is 4-6 weeks. Schema and CLI surfaces are not yet frozen — pin your install until v1.0. Star/watch to follow progress.
+> **Status:** Phase 5 shipped — the `pipewise-eval` GitHub Action posts sticky eval-report comments on PRs, validated end-to-end against a real production pipeline (FactSpark). Phase 6 (polish toward v1.0 launch) is in progress, with 380+ tests passing. Schema and CLI surfaces are not yet frozen — pin your install until v1.0. Star/watch to follow progress.
 
 [![CI](https://github.com/isthatamullet/pipewise/actions/workflows/ci.yml/badge.svg)](https://github.com/isthatamullet/pipewise/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
@@ -161,8 +161,8 @@ Full adapter links land here once Phase 4 ships.
 | 2 | 8 built-in scorers (exact match, regex, numeric tolerance, JSON schema, cost / latency budgets, LLM judge, embedding similarity) | ✅ Shipped |
 | 3 | `pipewise inspect`, `pipewise eval`, `pipewise diff` CLI | ✅ Shipped |
 | 4 | FactSpark + resume-tailor reference adapters | ✅ Shipped |
-| 5 | GitHub Action for PR-comment eval reports | In progress |
-| 6 | Polish + v1.0 launch | Upcoming |
+| 5 | GitHub Action for PR-comment eval reports | ✅ Shipped |
+| 6 | Polish + v1.0 launch | In progress |
 
 Each phase ships incrementally to `main` with tests and CI, with reference-pipeline validation gates at the end of every architectural phase.
 


### PR DESCRIPTION
## Summary

- Replaces the placeholder \`[Unreleased]\` paragraph in \`CHANGELOG.md\` with structured Keep a Changelog 1.1.0 entries.
- **Added:** renderer (#40), CLI entry point (#40, #41), composite GitHub Action (#41), \`docs/ci-integration.md\` (#42, #43, #44), \`CODE_OF_CONDUCT.md\` (#46), \`SECURITY.md\` (#48).
- **Changed:** \`README.md\` (#42, #46), \`CONTRIBUTING.md\` (#46), \`pyproject.toml\` (#46).
- \`[0.0.1]\` section and compare links unchanged.

This is a non-Critical Phase 6 polish-checklist item but valuable to land while the work is fresh.

## Test plan

- [x] File renders correctly in GitHub's preview (markdown valid, headings nest correctly)
- [x] \`ruff format --check\`, \`ruff check\`, \`mypy pipewise/\` all clean
- [x] Privacy-check hooks pass (staged + commit-msg + worktree)
- [x] Manual privacy sanity-check: no \`tyler.gohr@gmail.com\` in the file (the email-swap entry describes the migration in generic terms)
- [x] \`[0.0.1]\` section preserved verbatim
- [ ] Gemini Code Assist review addressed if any comments surface

Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)