### PR TITLE
Phase 6: README.md — Versioning + deprecation policy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,23 +172,19 @@ Pipewise follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Pre-1.0 (current)
 
-While pipewise is on `0.x`, **any release may include breaking changes**. This is the standard SemVer convention for pre-stable software. Pin tightly:
+While pipewise is on `0.x`, **any release may include breaking changes** — including patch-level releases (`0.1.2` → `0.1.3`). This is the standard SemVer convention for pre-stable software. Pin to an exact version:
 
 ```toml
-# Pin to a specific patch version pre-1.0:
 pipewise = "==0.1.2"
-
-# Or pin to a minor range if you accept patch-level changes:
-pipewise = ">=0.1,<0.2"
 ```
 
-The schema, CLI, and scorer protocols are still settling. v1.0 will lock them in; until then, expect occasional breakage and pin accordingly.
+The schema, CLI, and scorer protocols are still settling. v1.0 will lock them in; until then, exact-version pinning is the only way to guarantee no surprise breakage.
 
 ### Post-1.0 (planned)
 
 Once pipewise reaches v1.0, the following stability commitments apply:
 
-- **MAJOR** bumps (1.x → 2.x) — may include breaking changes to any public API. We commit to **at most one major bump every 12 months** so adopters have a predictable upgrade cadence.
+- **MAJOR** bumps (1.x → 2.x) — may include breaking changes to any public API. Major bumps are reserved for changes that genuinely warrant them; we don't commit to a calendar but expect them to be infrequent.
 - **MINOR** bumps (1.0 → 1.1) — additive only. New features, new optional fields, new scorers, new CLI flags. Existing public API stays source-compatible.
 - **PATCH** bumps (1.0.0 → 1.0.1) — bug fixes only.
 
@@ -201,7 +197,7 @@ Stable across MINOR bumps post-1.0:
 - All built-in scorers' constructor signatures and documented behavior
 - All `pipewise <command>` CLI commands and their documented flags
 - The **`EvalReport` JSON schema** written by `pipewise eval` (CI workflows depending on this format will not break across minor versions — see "Schema stability" below)
-- The adapter contract: `load_run(path) -> PipelineRun` and `default_scorers() -> tuple[list[StepScorer], list[RunScorer]]`
+- The adapter contract: `load_run(path) -> PipelineRun` (required) and `default_scorers() -> tuple[list[StepScorer], list[RunScorer]]` (optional — adapters that omit it just don't ship default-scorer suggestions)
 
 NOT part of the public API (may change in any release):
 
@@ -228,9 +224,9 @@ When a feature is deprecated post-1.0:
 
 1. A `DeprecationWarning` is added in a minor release, with the warning text pointing to the replacement.
 2. The deprecated feature continues to work for the remaining lifetime of the current major version.
-3. Removal happens in the next major release (≤12 months later).
+3. Removal happens in the next major release.
 
-Practically: anything deprecated in v1.x stays available until v2.0. You always have at least the time between deprecation and the next major bump to migrate, with a 12-month ceiling.
+Practically: anything deprecated in v1.x stays available until v2.0. Adopters always have at least the time between deprecation and the next major bump to migrate. We don't commit to a specific calendar for major bumps (see "Post-1.0" above), so deprecation warnings give you visibility but not a fixed timeline.
 
 ### Python version support
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,78 @@ Full adapter links land here once Phase 4 ships.
 
 Each phase ships incrementally to `main` with tests and CI, with reference-pipeline validation gates at the end of every architectural phase.
 
+## Versioning
+
+Pipewise follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### Pre-1.0 (current)
+
+While pipewise is on `0.x`, **any release may include breaking changes**. This is the standard SemVer convention for pre-stable software. Pin tightly:
+
+```toml
+# Pin to a specific patch version pre-1.0:
+pipewise = "==0.1.2"
+
+# Or pin to a minor range if you accept patch-level changes:
+pipewise = ">=0.1,<0.2"
+```
+
+The schema, CLI, and scorer protocols are still settling. v1.0 will lock them in; until then, expect occasional breakage and pin accordingly.
+
+### Post-1.0 (planned)
+
+Once pipewise reaches v1.0, the following stability commitments apply:
+
+- **MAJOR** bumps (1.x → 2.x) — may include breaking changes to any public API. We commit to **at most one major bump every 12 months** so adopters have a predictable upgrade cadence.
+- **MINOR** bumps (1.0 → 1.1) — additive only. New features, new optional fields, new scorers, new CLI flags. Existing public API stays source-compatible.
+- **PATCH** bumps (1.0.0 → 1.0.1) — bug fixes only.
+
+### What counts as the "public API"
+
+Stable across MINOR bumps post-1.0:
+
+- The `pipewise.PipelineRun`, `pipewise.StepExecution`, `pipewise.ScoreResult`, and `pipewise.EvalReport` Pydantic models, including all field names and types
+- The `pipewise.StepScorer` and `pipewise.RunScorer` Protocol signatures
+- All built-in scorers' constructor signatures and documented behavior
+- All `pipewise <command>` CLI commands and their documented flags
+- The **`EvalReport` JSON schema** written by `pipewise eval` (CI workflows depending on this format will not break across minor versions — see "Schema stability" below)
+- The adapter contract: `load_run(path) -> PipelineRun` and `default_scorers() -> tuple[list[StepScorer], list[RunScorer]]`
+
+NOT part of the public API (may change in any release):
+
+- Anything under `pipewise._*` or with a name starting with an underscore
+- The internal scorer-execution pipeline (how scorers are dispatched, what order they run in, etc. — only the protocols and built-in behavior are stable contracts)
+- Exact text of error messages
+- The `__repr__` output of any class
+- The `metadata: dict[str, Any]` extension field on schema models — adapters may put anything there, but pipewise makes no surface promises about how it's exposed
+
+### Schema stability (for adapter authors)
+
+The Pydantic schema is the load-bearing contract for adapter authors. Post-1.0:
+
+- **Adding a new optional field** is allowed in a minor release.
+- **Making a previously optional field required** requires a major bump.
+- **Removing or renaming a field** requires a major bump.
+- **Tightening validation** (e.g., narrowing accepted types) requires a major bump.
+
+If you write an adapter against pipewise v1.x, it will continue to work with pipewise v1.y for any y > x without changes.
+
+### Deprecation policy
+
+When a feature is deprecated post-1.0:
+
+1. A `DeprecationWarning` is added in a minor release, with the warning text pointing to the replacement.
+2. The deprecated feature continues to work for the remaining lifetime of the current major version.
+3. Removal happens in the next major release (≤12 months later).
+
+Practically: anything deprecated in v1.x stays available until v2.0. You always have at least the time between deprecation and the next major bump to migrate, with a 12-month ceiling.
+
+### Python version support
+
+Pipewise targets actively supported Python releases per the [official Python release schedule](https://devguide.python.org/versions/). Currently: **Python 3.11+**.
+
+When a Python version reaches its end-of-life, pipewise drops support for it in the next release (minor pre-1.0, major post-1.0). EOL'd Python versions don't receive security patches, so continuing to support them is a liability for adopters as well as for pipewise.
+
 ## License
 
 [Apache 2.0](LICENSE) — patent-protective, enterprise-friendly, no rug-pulls.


### PR DESCRIPTION
## Summary

Adds a 72-line \`## Versioning\` section to \`README.md\` documenting pipewise's stability contract. Section placed between \`## Roadmap\` and \`## License\` — where stability-conscious readers find it in the natural eye-path after the maturity-signal Roadmap section.

The locked decisions in this section reflect a senior-advisor reading of pipewise's situation: solo maintainer, pre-1.0 library, single reference adopter so far (FactSpark), \`pipewise-eval\` action shipped in Phase 5 making the EvalReport JSON schema a real downstream contract.

## Decision summary

| Axis | Decision | Why |
|---|---|---|
| Pre-1.0 stance | 0.x may break; pin tightly | Standard SemVer pre-stable convention |
| Post-1.0 majors | At most 1 per 12 months | Predictable upgrade cadence for adopters |
| EvalReport JSON schema | Public-API-stable post-1.0 | CI workflows depend on it; stability turns it into a load-bearing surface |
| Schema stability | Additive minors, removal/rename = major | Adapter authors need this contract |
| Deprecation cycle | Strict (deprecate in N.x → remove in N+1.0) | Solo-maintainer-realistic; not promising pydantic-style multi-year support |
| Python support | Follow Python EOL (currently 3.11+) | Lowest-overhead rule, no PyPI download stats needed |

## Test plan

- [x] Section renders correctly in GitHub's preview (markdown + tables + code blocks valid)
- [x] \`ruff format --check\`, \`ruff check\`, \`mypy pipewise/\` all clean
- [x] Privacy-check hooks pass (staged + commit-msg + worktree)
- [x] Manual privacy sanity-check: no \`tyler.gohr@gmail.com\` references; no category-language
- [x] Section structure: 6 subsections (Pre-1.0, Post-1.0, public API, schema stability, deprecation, Python support) — clear navigation
- [x] Section length: 72 lines (within 50-80 target)
- [ ] Gemini Code Assist review addressed if any comments surface

This is the last Critical (🚨) item in the planned 5-PR sitting. Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)