### PR TITLE
docs(ci): distinguish pipeline-input from pipewise-input dataset

### DIFF
--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -138,12 +138,13 @@ jobs:
           # 3. Run pipewise eval on the JSONL of PipelineRuns. Pipewise
           #    writes to a timestamped subdirectory under --output-root;
           #    we copy the produced file to a stable path for the artifact
-          #    upload below.
+          #    upload below. The per-adapter segment under reports/ keeps
+          #    the glob unambiguous in multi-adapter repos.
           pipewise eval \
             --adapter my_pipeline_pipewise.adapter \
             --dataset runs.jsonl \
-            --output-root reports/
-          cp reports/*/report.json report.json
+            --output-root reports/my_pipeline_pipewise/
+          cp reports/my_pipeline_pipewise/*/report.json report.json
 
       - uses: actions/upload-artifact@v4
         with:
@@ -227,8 +228,8 @@ jobs:
           pipewise eval \
             --adapter my_pipeline_pipewise.adapter \
             --dataset runs.jsonl \
-            --output-root reports/
-          cp reports/*/report.json report.json
+            --output-root reports/my_pipeline_pipewise/
+          cp reports/my_pipeline_pipewise/*/report.json report.json
 
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -122,14 +122,28 @@ jobs:
         run: |
           # Pre-v1.0 / pre-PyPI install — pin to a SHA or tag in CI.
           pip install git+https://github.com/isthatamullet/pipewise.git@main
-          # 1. Run your pipeline against the canonical dataset.
-          python -m my_pipeline.run --dataset golden.jsonl --output runs/
 
-          # 2. Run pipewise eval on the produced runs.
+          # 1. Run your pipeline against your canonical inputs (shape is
+          #    your pipeline's concern; this is just an example invocation).
+          python -m my_pipeline.run --inputs canonical-inputs.jsonl --output-dir runs/
+
+          # 2. Materialize PipelineRuns: call your adapter's load_run once
+          #    per completed run and write the results as JSONL — one
+          #    serialized PipelineRun per line. See `docs/adapter-guide.md`
+          #    "Where PipelineRun JSONL files come from" for the canonical
+          #    materialization-script pattern.
+          python -m my_pipeline_pipewise.build_dataset \
+            --runs-dir runs/ --output runs.jsonl
+
+          # 3. Run pipewise eval on the JSONL of PipelineRuns. Pipewise
+          #    writes to a timestamped subdirectory under --output-root;
+          #    we copy the produced file to a stable path for the artifact
+          #    upload below.
           pipewise eval \
             --adapter my_pipeline_pipewise.adapter \
-            --dataset golden.jsonl \
-            --output report.json
+            --dataset runs.jsonl \
+            --output-root reports/
+          cp reports/*/report.json report.json
 
       - uses: actions/upload-artifact@v4
         with:
@@ -207,11 +221,14 @@ jobs:
         run: |
           # Pre-v1.0 / pre-PyPI install — pin to a SHA or tag in CI.
           pip install git+https://github.com/isthatamullet/pipewise.git@main
-          python -m my_pipeline.run --dataset golden.jsonl --output runs/
+          python -m my_pipeline.run --inputs canonical-inputs.jsonl --output-dir runs/
+          python -m my_pipeline_pipewise.build_dataset \
+            --runs-dir runs/ --output runs.jsonl
           pipewise eval \
             --adapter my_pipeline_pipewise.adapter \
-            --dataset golden.jsonl \
-            --output report.json
+            --dataset runs.jsonl \
+            --output-root reports/
+          cp reports/*/report.json report.json
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Fixes two bugs in the YAML examples in `docs/ci-integration.md` that would prevent an adopter from copy-pasting them successfully:

- **Dual-purpose `golden.jsonl`** — the same filename was passed to both `python -m my_pipeline.run --dataset golden.jsonl ...` (pipeline input — shape is the user's concern) AND `pipewise eval --dataset golden.jsonl ...` (pipewise input — must be JSONL of serialized `PipelineRun`s). Two different file shapes; using the same name made the example unworkable. Renamed to `canonical-inputs.jsonl` (pipeline input) and `runs.jsonl` (pipewise input), and inserted the explicit materialization step (`build_dataset.py`) between them.
- **Fictional `--output report.json` flag** — `pipewise eval` does not have an `--output` flag. The actual flag is `--output-root <dir>` and reports are written to a timestamped subdirectory at `<root>/<timestamp>_<label>/report.json` (see `pipewise/runner/storage.py`). Replaced with `--output-root reports/` plus `cp reports/*/report.json report.json` to grab the produced file for the artifact upload.

Both fixes are applied to the minimal example workflow and the baseline workflow. **No code changes** — the YAML examples now match the actual CLI behavior shipped in #40, #41, #42-44.

Companion PR (separate): #56 — `docs(adapter-guide): clarify load_run invocation and JSONL materialization` (paradigm-level realignment with `pipewise/cli.py` invocation flow). Splitting because the two changes are conceptually independent and benefit from focused reviews.

## Test plan

- [ ] An adopter copy-pasting the `Minimal example workflow` block can run `pipewise eval` end-to-end without "unknown option" errors
- [ ] `cp reports/*/report.json report.json` grabs the timestamped report file in CI (single eval per workflow run = single match)
- [ ] Both example workflows (minimal + baseline) describe the same flow consistently
- [ ] `docs/adapter-guide.md` companion PR's "Where PipelineRun JSONL files come from" section and this PR's `build_dataset.py` reference match

🤖 Generated with [Claude Code](https://claude.com/claude-code)