### PR TITLE
docs(adapter-guide): add smoke-test recipe for end-to-end verification

### DIFF
--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -21,6 +21,130 @@ your-pipeline-repo/
             └── test_adapter.py
 ```
 
+## Smoke-test adapter in 5 minutes
+
+Before you wire an adapter into your real pipeline, it's worth confirming pipewise installs and runs end-to-end on your machine. This section walks through a self-contained smoke test — two short files in `/tmp/`, three synthetic runs, one clean pass.
+
+```python
+# /tmp/smoke/adapter.py
+"""Smoke-test adapter — a 3-step toy pipeline. Real adapters are larger
+and live in their pipeline's repo (see "Why the adapter lives in your
+repo" below); this one is intentionally tiny."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pipewise import PipelineRun, RunScorer, StepExecution, StepScorer
+from pipewise.scorers.budget import LatencyBudgetScorer
+from pipewise.scorers.regex import RegexScorer
+
+
+def load_run(path: Path) -> PipelineRun:
+    """Translate one raw run file into a canonical PipelineRun."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    base = datetime.now(UTC)
+
+    def step(idx: int, step_id: str, name: str) -> StepExecution:
+        return StepExecution(
+            step_id=step_id,
+            step_name=name,
+            started_at=base + timedelta(seconds=idx),
+            completed_at=base + timedelta(seconds=idx + 1),
+            status="completed",
+            latency_ms=1000,
+            outputs={"status": "ok", "topic": raw["topic"]},
+        )
+
+    return PipelineRun(
+        run_id=raw["run_id"],
+        pipeline_name="smoke-test",
+        started_at=base,
+        completed_at=base + timedelta(seconds=3),
+        status="completed",
+        total_latency_ms=3000,
+        steps=[
+            step(0, "load_article", "Load Article"),
+            step(1, "summarize", "Summarize"),
+            step(2, "check_hallucinations", "Check Hallucinations"),
+        ],
+        adapter_name="smoke-test-adapter",
+        adapter_version="0.1.0",
+    )
+
+
+def default_scorers() -> tuple[list[StepScorer], list[RunScorer]]:
+    """One step scorer + one run scorer — both pass cleanly on the data above."""
+    return (
+        [RegexScorer(field="status", pattern=r"^ok$", name="status-ok")],
+        [LatencyBudgetScorer(budget_ms=10_000, name="latency-cap")],
+    )
+```
+
+```python
+# /tmp/smoke/build_dataset.py
+"""Materialize synthetic PipelineRuns into a JSONL dataset for `pipewise eval`."""
+import json
+from pathlib import Path
+
+from adapter import load_run
+
+# Synthetic raw run inputs (would normally be your pipeline's actual outputs).
+runs_dir = Path("runs/")
+runs_dir.mkdir(exist_ok=True)
+for fx in [
+    {"run_id": "run_001", "topic": "weather-forecast"},
+    {"run_id": "run_002", "topic": "earnings-report"},
+    {"run_id": "run_003", "topic": "product-launch"},
+]:
+    (runs_dir / f"{fx['run_id']}.json").write_text(json.dumps(fx))
+
+# Call adapter.load_run on each raw file, write JSONL — one PipelineRun per line.
+with Path("dataset.jsonl").open("w", encoding="utf-8") as out:
+    for raw_path in sorted(runs_dir.glob("*.json")):
+        out.write(load_run(raw_path).model_dump_json() + "\n")
+```
+
+Then run it:
+
+```bash
+mkdir -p /tmp/smoke && cd /tmp/smoke
+# (paste the two files above into adapter.py and build_dataset.py)
+python build_dataset.py
+PYTHONPATH=. pipewise eval --adapter adapter --dataset dataset.jsonl
+```
+
+`PYTHONPATH=.` is required so pipewise can `import adapter` from the current directory; in a real adapter installed via `pip install -e .` (see the package layout below), this isn't needed. Expected output:
+
+```
+Evaluated 3 run(s) with 1 step scorer(s) + 1 run scorer(s).
+Scores: 12/12 passing (0 failing).
+Report: pipewise/reports/<timestamp>_dataset/report.json
+```
+
+Bonus — inspect a single run to see pipewise's pretty-printer output:
+
+```bash
+head -n 1 dataset.jsonl > one-run.json
+pipewise inspect one-run.json
+```
+
+```
+Run:      run_001
+Pipeline: smoke-test
+Adapter:  smoke-test-adapter@0.1.0
+Status:   completed  Started: ...  Duration: 3.00s
+
+Steps (3):
+  1. load_article [completed] latency=1000ms  (1.00s)
+     inputs:  {}
+     outputs: {'status': 'ok', 'topic': 'weather-forecast'}
+  ...
+```
+
+If both commands succeed, pipewise is installed correctly and the adapter contract is intact. Now you're ready to write a real adapter for your pipeline — read on.
+
 ## Why the adapter lives in your repo, not in pipewise
 
 This is the architectural commitment that makes pipewise's "general framework" claim verifiable. Your pipeline depends on pipewise (via `pip install pipewise`); pipewise has zero knowledge of your pipeline. A reviewer cloning the pipewise repo sees no traces of any specific pipeline in the core code, and the `examples/` directory only links to external adapter implementations.

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -98,7 +98,7 @@ for fx in [
     {"run_id": "run_002", "topic": "earnings-report"},
     {"run_id": "run_003", "topic": "product-launch"},
 ]:
-    (runs_dir / f"{fx['run_id']}.json").write_text(json.dumps(fx))
+    (runs_dir / f"{fx['run_id']}.json").write_text(json.dumps(fx), encoding="utf-8")
 
 # Call adapter.load_run on each raw file, write JSONL — one PipelineRun per line.
 with Path("dataset.jsonl").open("w", encoding="utf-8") as out:


### PR DESCRIPTION
## Summary

Adds a **"Smoke-test adapter in 5 minutes"** §3 to `docs/adapter-guide.md` — a self-contained synthetic-adapter recipe adopters can copy-paste into `/tmp/` to confirm pipewise installs and runs end-to-end before investing time writing a real adapter for their pipeline.

The section sits between the existing "What an adapter does" (which gives the conceptual intro) and "Why the adapter lives in your repo" (which is a deeper architectural justification). Two short files:

- `adapter.py` (~50 lines) — single-file synthetic adapter exposing `load_run` + `default_scorers`. Three steps (`load_article`, `summarize`, `check_hallucinations`) with hardcoded synthetic outputs.
- `build_dataset.py` (~15 lines) — generates 3 raw run fixtures + materializes them into `dataset.jsonl` via `adapter.load_run`. This is the same Model-B materialization pattern the "Where PipelineRun JSONL files come from" section (#56) describes.

Two scorers chosen to **pass cleanly** on the synthetic data so first-timers see `12/12 passing (0 failing)` rather than by-design noise:
- `RegexScorer(field="status", pattern=r"^ok$")` step-level
- `LatencyBudgetScorer(budget_ms=10_000)` run-level

Bonus `pipewise inspect one-run.json` demo at the end shows the pretty-printer output adopters get for free once the canonical PipelineRun shape is in hand.

**Why this matters:** the existing adapter-guide assumed adopters already had a real pipeline they wanted to evaluate. Strangers evaluating pipewise-as-tool ("let me try it on a toy first") had no on-ramp — both worked examples are ~250 LOC and reference external pipeline repos. This section gives them one.

## Verification

The recipe was verified working end-to-end before documenting:
- `python build_dataset.py` produces `runs/*.json` + `dataset.jsonl` with 3 synthetic PipelineRuns
- `PYTHONPATH=. pipewise eval --adapter adapter --dataset dataset.jsonl` produces `Scores: 12/12 passing (0 failing).`
- `pipewise inspect one-run.json` produces the readable run header + 3-step listing shown in the doc

The `PYTHONPATH=.` note is documented inline so adopters don't hit a `ModuleNotFoundError` mystery — `importlib.import_module` (`pipewise/runner/adapter.py:60`) reads `sys.path`, which doesn't include cwd by default for console-script entry points. Real adapters installed via `pip install -e .` don't need this; the smoke-test layout (single file in `/tmp/`) does.

## Test plan

- [ ] An adopter copy-pasting the two code blocks into `/tmp/smoke/` and following the bash invocations gets a clean `12/12 passing` eval
- [ ] The `pipewise inspect` bonus output matches what's documented
- [ ] The section reads naturally between "What an adapter does" and "Why the adapter lives in your repo" — neither orphaned nor redundant
- [ ] `PYTHONPATH=.` caveat is clear enough that adopters don't hit a `ModuleNotFoundError` mystery

🤖 Generated with [Claude Code](https://claude.com/claude-code)