### PR TITLE
docs(scorers): add TOML config + pipewise diff sections

### DIFF
--- a/docs/scorers.md
+++ b/docs/scorers.md
@@ -183,6 +183,55 @@ uv run python examples/demo_phase2_scorers.py
 
 ---
 
+## Configuring scorers via TOML
+
+`pipewise eval --scorers <path.toml>` overrides the adapter's `default_scorers()` with a TOML-defined scorer set. Use this when the canonical scorer set differs by environment — e.g., a tighter `LatencyBudgetScorer` budget on CI than on local dev, or opting into `LlmJudgeScorer` only on the baseline workflow where reproducibility matters and the API cost is acceptable.
+
+The file format is a `[scorers.<name>]` table per scorer. The section key becomes the scorer's `name`; `class` is a dotted import path; all other keys are forwarded as constructor kwargs:
+
+```toml
+[scorers.has-status]
+class = "pipewise.scorers.regex.RegexScorer"
+field = "status"
+pattern = "^ok$"
+
+[scorers.cost-cap]
+class = "pipewise.scorers.budget.CostBudgetScorer"
+budget_usd = 0.10
+on_missing = "skip"
+
+[scorers.latency-cap]
+class = "pipewise.scorers.budget.LatencyBudgetScorer"
+budget_ms = 10000
+on_missing = "skip"
+```
+
+Save as `scorers.toml` and invoke:
+
+```bash
+pipewise eval --adapter your_pipeline_pipewise.adapter \
+              --dataset path/to/dataset.jsonl \
+              --scorers scorers.toml
+```
+
+Expected output for a 3-run dataset where every step has `status: "ok"`:
+
+```
+Evaluated 3 run(s) with 1 step scorer(s) + 2 run scorer(s).
+Scores: 15/15 passing (0 failing).
+Report: pipewise/reports/<timestamp>_dataset/report.json
+```
+
+A few rules worth knowing:
+
+- **Step vs. run classification is automatic.** Pipewise inspects each scorer's `score(actual=...)` annotation: `StepExecution` → step scorer, `PipelineRun` → run scorer. Custom scorers that don't have resolvable type hints fall back to Protocol-isinstance fits.
+- **Missing-class errors surface at config-load time, not eval time.** A typo in `class = "..."` produces a `ScorerConfigError` *before* the eval starts, so failed runs are never partially scored.
+- **Constructor kwargs are forwarded as-is.** If a scorer's `__init__` signature changes, your TOML breaks at load time with a clear `TypeError`-shaped message — no silent ignore.
+- **`name` is auto-supplied from the section key.** You can override with an explicit `name = "..."` line if you want a different display name than the TOML key.
+- **TOML inline tables work** for nested config (e.g., `JsonSchemaScorer`'s `schema = { type = "object", ... }`).
+
+---
+
 ## Writing your own scorer
 
 A scorer is any class with a `name` attribute and a `score()` method matching the protocol shape. The simplest possible step scorer:
@@ -203,3 +252,66 @@ class IsNonEmptyScorer:
 ```
 
 Pipewise's runner accepts any object satisfying the protocol — built-in or yours — without further registration.
+
+---
+
+## Comparing two reports with `pipewise diff`
+
+`pipewise eval` writes a timestamped `EvalReport` per run; `pipewise diff` compares two of them and surfaces what changed. Same code path the GitHub Action uses internally — the standalone CLI is for local "did my change improve scores or regress?" checks before pushing.
+
+```bash
+pipewise diff path/to/baseline/report.json path/to/current/report.json
+```
+
+The diff categorizes every `(run_id, step_id, scorer_name)` triple into one of: regression (was passing, now failing), improvement (was failing, now passing), score delta (pass status unchanged but score moved), or absent-in-one (scorer added/removed across reports). The text output groups them with counts:
+
+```
+Newly failing (regressions) (3):
+  run_001 / latency-cap  score 1.000 → 0.000  passed True → False
+  run_002 / latency-cap  score 1.000 → 0.000  passed True → False
+  run_003 / latency-cap  score 1.000 → 0.000  passed True → False
+
+Summary: 3 regressed, 0 improved, 0 score deltas
+```
+
+When nothing changed across the two reports:
+
+```
+Summary: 0 regressed, 0 improved, 0 score deltas
+```
+
+**Exit codes** make `pipewise diff` usable as a CI gate even outside the GitHub Action:
+
+- `0` — no regressions (improvements and score-deltas don't affect exit status)
+- `1` — at least one regression
+- `2` — usage error (file not found, malformed JSON, etc.)
+
+**JSON format** is available via `--format json` for tooling that wants the structured `ReportDiff` shape:
+
+```bash
+pipewise diff --format json baseline/report.json current/report.json
+```
+
+```json
+{
+  "runs_a_only": [],
+  "runs_b_only": [],
+  "regressions": [
+    {
+      "run_id": "run_001",
+      "step_id": null,
+      "scorer_name": "latency-cap",
+      "score_a": 1.0,
+      "score_b": 0.0,
+      "passed_a": true,
+      "passed_b": false
+    }
+  ],
+  "improvements": [],
+  "score_deltas": [],
+  "absent_in_a": [],
+  "absent_in_b": []
+}
+```
+
+For the automated PR-comment form of the same diff (sticky comment with verdict line + roll-up table), see [`docs/ci-integration.md`](ci-integration.md) — the `pipewise-eval` GitHub Action wraps `compute_diff()` and renders the result as Markdown.


### PR DESCRIPTION
## Summary

Adds two new sections to `docs/scorers.md` that document features shipped in Phase 3 but never surfaced in user-facing docs:

### 1. "Configuring scorers via TOML" (~50 lines)

The `pipewise eval --scorers <toml>` flag has been live since Phase 3 (#25); the TOML format was only documented in the `pipewise/runner/scorer_config.py:1-17` docstring. Lifting it into scorers.md so adopters configuring scorers via TOML (CI-time tighter budgets, opt-in `LlmJudgeScorer`, etc.) don't have to source-read.

Includes:
- TOML structure: `[scorers.<name>]` sections, `class` (dotted import path), kwargs forwarded to constructor
- Worked example: 3 scorers covering both step (`RegexScorer`) and run (`CostBudgetScorer`, `LatencyBudgetScorer`) shapes
- Invocation + verbatim "15/15 passing" output captured from a real run
- Five behavioral notes (automatic step/run classification via type hints, load-time error surfacing, kwargs pass-through, `name` auto-population, TOML inline-table support for nested config like `JsonSchemaScorer`'s `schema =` kwarg)

### 2. "Comparing two reports with `pipewise diff`" (~50 lines)

`pipewise diff` is the third of three CLI verbs (`inspect`, `eval`, `diff`) and the only one without a doc surface. The README quickstart mentions it in 2 lines; this section covers the standalone CLI form for local "did my change regress anything?" workflows.

Includes:
- What the diff categorizes (regressions / improvements / score deltas / absent-in-one)
- Verbatim text output for the 3-regressions case + the empty no-changes case
- Exit codes: 0 (no regressions), 1 (regressions present), 2 (usage error)
- `--format json` invocation + sample `ReportDiff` payload showing the structured shape
- Cross-link to `docs/ci-integration.md` for the automated PR-comment form (the GitHub Action wraps the same `compute_diff()` and renders Markdown)

## Verification

Both sections include verbatim output captured from real commands run against synthetic data:
- TOML: built a `scorers.toml` with the 3 example scorers, ran `pipewise eval --scorers scorers.toml` against a 3-run synthetic dataset, captured `Scores: 15/15 passing (0 failing).`
- Diff: ran a second eval with a tighter `LatencyBudgetScorer` budget to produce 3 regressions, captured both text and `--format json` output. Also ran `pipewise diff` against the same report twice to capture the empty no-changes output.
- Empty diff exit code: `0` ✓
- Regressions diff exit code: `1` ✓ (matches `cli.py:_REGRESSION_EXIT_CODE`)

## Test plan

- [ ] Adopter copy-pasting the TOML example into `scorers.toml` and running `pipewise eval --scorers scorers.toml --adapter ... --dataset ...` gets a load-time error (rather than runtime error) if any class path is invalid
- [ ] `pipewise diff a.json b.json` exits 0 when reports are identical, 1 when there are regressions, 2 on usage errors
- [ ] `pipewise diff --format json` produces the exact `ReportDiff` shape documented in the JSON snippet
- [ ] Cross-link from scorers.md → ci-integration.md resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)