### PR TITLE
cli(eval): make --adapter optional when --scorers is supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Until v1.0, **minor and patch versions may include breaking changes** — pipewi
 
 ### Changed
 
+- **`pipewise eval --adapter` is no longer required when `--scorers <toml>` is supplied.** Previously the flag was structurally required by Typer but unused by the explicit-scorers branch; the inconsistency was surfaced via Gemini Code Assist on PR #56. Backward-compatible — existing scripts that pass `--adapter` continue to work; new invocations may omit it when `--scorers` is present. Supplying neither flag now raises a clear usage error (exit code 2).
 - **`README.md`** — Phase 5 status updated to shipped (status banner + roadmap table) (#50); documentation index now links to `docs/scorers.md` and `docs/ci-integration.md` (#42); Contributing section now links to `CODE_OF_CONDUCT.md` (#46).
 - **`CONTRIBUTING.md`** — Code of Conduct section migrated from an inline paragraph to a link to the formal `CODE_OF_CONDUCT.md`; reporting contact updated to `hello@pipewise.dev`. (#46)
 - **`pyproject.toml`** — author email migrated from the maintainer's personal gmail to project-bounded `hello@pipewise.dev` (Workspace alias). Affects published PyPI metadata when pipewise releases. (#46)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Until v1.0, **minor and patch versions may include breaking changes** — pipewi
 
 ### Changed
 
-- **`pipewise eval --adapter` is no longer required when `--scorers <toml>` is supplied.** Previously the flag was structurally required by Typer but unused by the explicit-scorers branch; the inconsistency was surfaced via Gemini Code Assist on PR #56. Backward-compatible — existing scripts that pass `--adapter` continue to work; new invocations may omit it when `--scorers` is present. Supplying neither flag now raises a clear usage error (exit code 2).
+- **`pipewise eval --adapter`** — no longer required when `--scorers <toml>` is supplied. Previously the flag was structurally required by Typer but unused by the explicit-scorers branch; the inconsistency was surfaced via Gemini Code Assist on PR #56. Backward-compatible — existing scripts that pass `--adapter` continue to work; new invocations may omit it when `--scorers` is present. Supplying neither flag now raises a clear usage error (exit code 2).
 - **`README.md`** — Phase 5 status updated to shipped (status banner + roadmap table) (#50); documentation index now links to `docs/scorers.md` and `docs/ci-integration.md` (#42); Contributing section now links to `CODE_OF_CONDUCT.md` (#46).
 - **`CONTRIBUTING.md`** — Code of Conduct section migrated from an inline paragraph to a link to the formal `CODE_OF_CONDUCT.md`; reporting contact updated to `hello@pipewise.dev`. (#46)
 - **`pyproject.toml`** — author email migrated from the maintainer's personal gmail to project-bounded `hello@pipewise.dev` (Workspace alias). Affects published PyPI metadata when pipewise releases. (#46)

--- a/pipewise/cli.py
+++ b/pipewise/cli.py
@@ -115,12 +115,13 @@ def eval_cmd(
         typer.Option("--dataset", help="Path to a JSONL dataset of pipeline runs."),
     ],
     adapter: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--adapter",
-            help="Module path of the adapter (e.g. 'factspark.integrations.pipewise.adapter').",
+            help="Module path of the adapter (e.g. 'factspark.integrations.pipewise.adapter'). "
+            "Required unless --scorers <toml> is supplied.",
         ),
-    ],
+    ] = None,
     scorers_path: Annotated[
         Path | None,
         typer.Option(
@@ -145,6 +146,13 @@ def eval_cmd(
     ] = None,
 ) -> None:
     """Run scorers across a dataset and persist an EvalReport."""
+    if adapter is None and scorers_path is None:
+        typer.echo(
+            "Error: must supply at least one of --adapter or --scorers.",
+            err=True,
+        )
+        raise typer.Exit(code=_USAGE_ERROR_EXIT_CODE)
+
     # Resolve scorers — either explicit override or adapter defaults.
     if scorers_path is not None:
         try:
@@ -153,6 +161,7 @@ def eval_cmd(
             typer.echo(f"Error loading scorer config: {exc}", err=True)
             raise typer.Exit(code=_USAGE_ERROR_EXIT_CODE) from exc
     else:
+        assert adapter is not None  # narrowed by the guard above
         try:
             defaults = resolve_default_scorers(adapter)
         except AdapterError as exc:

--- a/tests/cli/test_eval_cmd.py
+++ b/tests/cli/test_eval_cmd.py
@@ -259,6 +259,58 @@ class TestEvalCommand:
         combined = result.stdout + (result.stderr or "")
         assert "not found" in combined.lower()
 
+    def test_scorers_toml_works_without_adapter_flag(self, tmp_path: Path) -> None:
+        # When --scorers is supplied, --adapter is no longer required: the
+        # explicit-scorers branch never resolves the adapter.
+        dataset = tmp_path / "ds.jsonl"
+        _write_dataset(dataset, [_make_run("run_1")])
+        config = tmp_path / "scorers.toml"
+        config.write_text(
+            """
+            [scorers.regex-passes]
+            class = "pipewise.scorers.regex.RegexScorer"
+            field = "value"
+            pattern = "^ok$"
+            """
+        )
+        output_root = tmp_path / "reports"
+
+        result = runner.invoke(
+            app,
+            [
+                "eval",
+                "--dataset",
+                str(dataset),
+                "--scorers",
+                str(config),
+                "--output-root",
+                str(output_root),
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert "1/1 passing" in result.stdout
+
+    def test_neither_adapter_nor_scorers_is_clear_error(self, tmp_path: Path) -> None:
+        dataset = tmp_path / "ds.jsonl"
+        _write_dataset(dataset, [_make_run("run_1")])
+
+        result = runner.invoke(
+            app,
+            [
+                "eval",
+                "--dataset",
+                str(dataset),
+                "--output-root",
+                str(tmp_path / "reports"),
+            ],
+        )
+
+        assert result.exit_code == 2
+        combined = result.stdout + (result.stderr or "")
+        assert "--adapter" in combined
+        assert "--scorers" in combined
+
     def test_dataset_name_defaults_to_filename_stem(
         self, tmp_path: Path, adapter_with_defaults: str
     ) -> None:


### PR DESCRIPTION
## Summary

- `pipewise eval --adapter` is no longer structurally required by Typer when `--scorers <toml>` is supplied. The explicit-scorers branch never resolves the adapter; making the flag optional removes the redundant argument that the docs in #56 had to apologize for.
- New early-exit guard with exit code 2 + clear message when neither flag is supplied: `Error: must supply at least one of --adapter or --scorers.`
- Backward-compatible. Existing scripts (with or without `--scorers`) continue to work — the previously-required `--adapter` still passes through cleanly.

## Why

Closes the public commitment from PR #56's line-23 reply — the `--adapter` redundancy under `--scorers` was flagged by Gemini Code Assist as a doc-vs-CLI inconsistency. The doc PR shipped with a placeholder note ("a follow-up PR will make `--adapter` optional"); this is that follow-up.

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes  
- [x] `uv run mypy pipewise/` passes
- [x] `uv run pytest` — 410 passed, 1 skipped (LlmJudge real-API)
- [x] New test: `pipewise eval --scorers <toml> --dataset <path>` works without `--adapter` (new happy path)
- [x] New test: `pipewise eval --dataset <path>` (neither flag) raises usage error with exit code 2
- [x] Existing tests still pass without modification — the older `--adapter`-supplied invocations continue to work
- [x] Manual smoke: ran all three patterns (`--scorers` alone, neither flag, both flags) end-to-end against a synthetic dataset

## CHANGELOG

Added under `[Unreleased]` → `Changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)