### PR TITLE
cli(eval): surface failure clustering in eval summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Until v1.0, **minor and patch versions may include breaking changes** — pipewi
 - **`SECURITY.md`** — vulnerability reporting policy. Leads with GitHub Security Advisories as the preferred private channel; email fallback to `security@pipewise.dev`. Pre-1.0 supported-versions stance, best-effort response timeline (acknowledgment within 2 business days, initial assessment within 5), brief coordinated-disclosure process, and an explicit out-of-scope section. (#48)
 - **`docs/scorers.md`** — new "Reading `report.json`" section covering the report shape (`step_scores` / `run_scores` naming, `result.{score, passed, reasoning, metadata}` nesting), the explicit reports-don't-carry-step-outputs note with a side-by-side report+dataset code recipe, and the aggregation-helper methods on `EvalReport`. New "What `pipewise diff` answers (and what it doesn't)" subsection clarifying that `diff` is keyed on `(run_id, step_id, scorer_name)` triples — useful for "did rerunning the same dataset surface a regression?" but not for "is my pipeline trending better over time?" Both additions surfaced by live-fire dogfooding on FactSpark.
 
+### Added
+
+- **`pipewise eval`** — failure-clustering hint in the summary output. When more than one score fails on the same `(step_id, scorer_name)`, the eval prints a `Top failure: N of <step>/<scorer> (<reason>)` line so adopters can spot patterns without drilling into `report.json`. Suppressed when failures don't cluster (each failure is unique). Reasoning longer than 80 characters is truncated with `...`.
+
 ### Changed
 
 - **`pipewise eval --adapter`** — no longer required when `--scorers <toml>` is supplied. Previously the flag was structurally required by Typer but unused by the explicit-scorers branch; the inconsistency was surfaced via Gemini Code Assist on PR #56. Backward-compatible — existing scripts that pass `--adapter` continue to work; new invocations may omit it when `--scorers` is present. Supplying neither flag now raises a clear usage error (exit code 2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ Until v1.0, **minor and patch versions may include breaking changes** — pipewi
 - **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, drop-in template with `hello@pipewise.dev` as the enforcement contact. (#46)
 - **`SECURITY.md`** — vulnerability reporting policy. Leads with GitHub Security Advisories as the preferred private channel; email fallback to `security@pipewise.dev`. Pre-1.0 supported-versions stance, best-effort response timeline (acknowledgment within 2 business days, initial assessment within 5), brief coordinated-disclosure process, and an explicit out-of-scope section. (#48)
 - **`docs/scorers.md`** — new "Reading `report.json`" section covering the report shape (`step_scores` / `run_scores` naming, `result.{score, passed, reasoning, metadata}` nesting), the explicit reports-don't-carry-step-outputs note with a side-by-side report+dataset code recipe, and the aggregation-helper methods on `EvalReport`. New "What `pipewise diff` answers (and what it doesn't)" subsection clarifying that `diff` is keyed on `(run_id, step_id, scorer_name)` triples — useful for "did rerunning the same dataset surface a regression?" but not for "is my pipeline trending better over time?" Both additions surfaced by live-fire dogfooding on FactSpark.
-
-### Added
-
 - **`pipewise eval`** — failure-clustering hint in the summary output. When more than one score fails on the same `(step_id, scorer_name)`, the eval prints a `Top failure: N of <step>/<scorer> (<reason>)` line so adopters can spot patterns without drilling into `report.json`. Suppressed when failures don't cluster (each failure is unique). Reasoning longer than 80 characters is truncated with `...`.
 
 ### Changed

--- a/pipewise/cli.py
+++ b/pipewise/cli.py
@@ -237,30 +237,26 @@ def _top_failure_cluster(report: EvalReport) -> dict[str, Any] | None:
             if entry.result.passed:
                 continue
             key: tuple[str | None, str] = (entry.step_id, entry.scorer_name)
-            cluster = clusters.setdefault(
-                key,
-                {
+            if key not in clusters:
+                clusters[key] = {
                     "count": 0,
                     "scorer_name": entry.scorer_name,
                     "step_id": entry.step_id,
                     "reasoning": entry.result.reasoning,
-                },
-            )
-            cluster["count"] += 1
+                }
+            clusters[key]["count"] += 1
         for run_entry in run.run_scores:
             if run_entry.result.passed:
                 continue
             key = (None, run_entry.scorer_name)
-            cluster = clusters.setdefault(
-                key,
-                {
+            if key not in clusters:
+                clusters[key] = {
                     "count": 0,
                     "scorer_name": run_entry.scorer_name,
                     "step_id": None,
                     "reasoning": run_entry.result.reasoning,
-                },
-            )
-            cluster["count"] += 1
+                }
+            clusters[key]["count"] += 1
     if not clusters:
         return None
     return max(clusters.values(), key=lambda c: c["count"])

--- a/pipewise/cli.py
+++ b/pipewise/cli.py
@@ -12,7 +12,7 @@ The CLI is the wiring layer; logic lives in `pipewise.runner.*`.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from pydantic import ValidationError
@@ -197,10 +197,73 @@ def eval_cmd(
         f"{len(step_scorers)} step scorer(s) + {len(run_scorers)} run scorer(s)."
     )
     typer.echo(f"Scores: {passing}/{total} passing ({failing} failing).")
+
+    # Failure-clustering hint: if multiple failures share the same
+    # (step_id, scorer_name), surface the largest cluster so adopters
+    # can spot patterns without drilling into report.json.
+    if failing > 0:
+        top = _top_failure_cluster(report)
+        if top is not None and top["count"] > 1:
+            label_parts = []
+            if top["step_id"] is not None:
+                label_parts.append(top["step_id"])
+            label_parts.append(top["scorer_name"])
+            label = "/".join(label_parts)
+            line = f"Top failure: {top['count']} of {label}"
+            if top["reasoning"]:
+                reason = top["reasoning"]
+                if len(reason) > 80:
+                    reason = reason[:77] + "..."
+                line = f"{line} ({reason})"
+            typer.echo(line)
+
     typer.echo(f"Report: {report_path}")
 
     if failing > 0:
         raise typer.Exit(code=_REGRESSION_EXIT_CODE)
+
+
+def _top_failure_cluster(report: EvalReport) -> dict[str, Any] | None:
+    """Aggregate failing scores by (step_id, scorer_name); return the
+    largest cluster, or None if there are no failures.
+
+    Returns a dict with `count`, `scorer_name`, `step_id` (or None for
+    run scorers), and `reasoning` (from the first failure in the cluster
+    — failures within a cluster typically share the same reasoning).
+    """
+    clusters: dict[tuple[str | None, str], dict[str, Any]] = {}
+    for run in report.runs:
+        for entry in run.step_scores:
+            if entry.result.passed:
+                continue
+            key: tuple[str | None, str] = (entry.step_id, entry.scorer_name)
+            cluster = clusters.setdefault(
+                key,
+                {
+                    "count": 0,
+                    "scorer_name": entry.scorer_name,
+                    "step_id": entry.step_id,
+                    "reasoning": entry.result.reasoning,
+                },
+            )
+            cluster["count"] += 1
+        for run_entry in run.run_scores:
+            if run_entry.result.passed:
+                continue
+            key = (None, run_entry.scorer_name)
+            cluster = clusters.setdefault(
+                key,
+                {
+                    "count": 0,
+                    "scorer_name": run_entry.scorer_name,
+                    "step_id": None,
+                    "reasoning": run_entry.result.reasoning,
+                },
+            )
+            cluster["count"] += 1
+    if not clusters:
+        return None
+    return max(clusters.values(), key=lambda c: c["count"])
 
 
 # ─── diff (#26) ───────────────────────────────────────────────────────────────

--- a/tests/cli/test_eval_cmd.py
+++ b/tests/cli/test_eval_cmd.py
@@ -294,7 +294,7 @@ class TestEvalCommand:
     def test_multi_run_failure_cluster_surfaces_top_failure_line(
         self, tmp_path: Path, adapter_with_failing_defaults: str
     ) -> None:
-        # 3 runs × always-fail step scorer = 3 identical failures.
+        # 3 runs x always-fail step scorer = 3 identical failures.
         # The eval summary should emit a "Top failure: 3 of s1/always-fail (nope)" line.
         dataset = tmp_path / "ds.jsonl"
         _write_dataset(

--- a/tests/cli/test_eval_cmd.py
+++ b/tests/cli/test_eval_cmd.py
@@ -291,6 +291,149 @@ class TestEvalCommand:
         assert result.exit_code == 0, result.stdout
         assert "1/1 passing" in result.stdout
 
+    def test_multi_run_failure_cluster_surfaces_top_failure_line(
+        self, tmp_path: Path, adapter_with_failing_defaults: str
+    ) -> None:
+        # 3 runs × always-fail step scorer = 3 identical failures.
+        # The eval summary should emit a "Top failure: 3 of s1/always-fail (nope)" line.
+        dataset = tmp_path / "ds.jsonl"
+        _write_dataset(
+            dataset,
+            [_make_run("run_1"), _make_run("run_2"), _make_run("run_3")],
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "eval",
+                "--dataset",
+                str(dataset),
+                "--adapter",
+                adapter_with_failing_defaults,
+                "--output-root",
+                str(tmp_path / "reports"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "0/3 passing" in result.stdout
+        assert "Top failure:" in result.stdout
+        assert "3 of s1/always-fail" in result.stdout
+        assert "nope" in result.stdout
+
+    def test_single_failure_suppresses_top_failure_line(
+        self, tmp_path: Path, adapter_with_failing_defaults: str
+    ) -> None:
+        # Only 1 run → top cluster has count=1 → no "Top failure" line
+        # (clustering hint only adds value when there's an actual cluster).
+        dataset = tmp_path / "ds.jsonl"
+        _write_dataset(dataset, [_make_run("run_1")])
+
+        result = runner.invoke(
+            app,
+            [
+                "eval",
+                "--dataset",
+                str(dataset),
+                "--adapter",
+                adapter_with_failing_defaults,
+                "--output-root",
+                str(tmp_path / "reports"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "0/1 passing" in result.stdout
+        assert "Top failure:" not in result.stdout
+
+    def test_run_scorer_cluster_omits_step_id_from_label(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A run scorer that always fails should produce a cluster keyed on
+        # the scorer name only (no step_id) — output line shows "N of <name>"
+        # without a step prefix.
+        from pipewise import ScoreResult
+
+        class _AlwaysFailRunScorer:
+            name = "run-fail"
+
+            def score(self, run: PipelineRun) -> ScoreResult:
+                return ScoreResult(score=0.0, passed=False, reasoning="run-level-fail")
+
+        def default_scorers() -> tuple[list[object], list[object]]:
+            return ([], [_AlwaysFailRunScorer()])
+
+        name = "fake_run_scorer_fail"
+        _install_adapter(name, {"load_run": lambda p: None, "default_scorers": default_scorers})
+        monkeypatch.setitem(sys.modules, name, sys.modules[name])
+
+        dataset = tmp_path / "ds.jsonl"
+        _write_dataset(dataset, [_make_run("run_1"), _make_run("run_2")])
+
+        result = runner.invoke(
+            app,
+            [
+                "eval",
+                "--dataset",
+                str(dataset),
+                "--adapter",
+                name,
+                "--output-root",
+                str(tmp_path / "reports"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Top failure: 2 of run-fail" in result.stdout
+        # No step_id slash for run-level scorers.
+        assert "/run-fail" not in result.stdout
+        assert "run-level-fail" in result.stdout
+
+    def test_long_reasoning_is_truncated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reasoning longer than 80 chars should appear with a "..." suffix.
+        from pipewise import ScoreResult
+
+        long_reason = "x" * 200
+
+        class _LongReasonStepScorer:
+            name = "long-reason"
+
+            def score(
+                self, actual: StepExecution, expected: StepExecution | None = None
+            ) -> ScoreResult:
+                return ScoreResult(score=0.0, passed=False, reasoning=long_reason)
+
+        def default_scorers() -> tuple[list[object], list[object]]:
+            return ([_LongReasonStepScorer()], [])
+
+        name = "fake_long_reason"
+        _install_adapter(name, {"load_run": lambda p: None, "default_scorers": default_scorers})
+        monkeypatch.setitem(sys.modules, name, sys.modules[name])
+
+        dataset = tmp_path / "ds.jsonl"
+        _write_dataset(dataset, [_make_run("run_1"), _make_run("run_2")])
+
+        result = runner.invoke(
+            app,
+            [
+                "eval",
+                "--dataset",
+                str(dataset),
+                "--adapter",
+                name,
+                "--output-root",
+                str(tmp_path / "reports"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Top failure:" in result.stdout
+        assert "..." in result.stdout
+        # The full 200-char reasoning should NOT be in the summary line.
+        assert long_reason not in result.stdout
+
     def test_neither_adapter_nor_scorers_is_clear_error(self, tmp_path: Path) -> None:
         dataset = tmp_path / "ds.jsonl"
         _write_dataset(dataset, [_make_run("run_1")])


### PR DESCRIPTION
## Summary

When `pipewise eval` produces multiple failures that share the same `(step_id, scorer_name)`, surface that pattern as a one-line hint in the summary output. Previously the summary only said "N failing" — adopters had to drill into `report.json` to learn whether the N failures were all the same shape or N different shapes.

```
Evaluated 14 run(s) with 1 step scorer(s) + 2 run scorer(s).
Scores: 112/126 passing (14 failing).
Top failure: 14 of verify_claims/article-body-present (field 'full_article_content' missing from outputs)
Report: /tmp/.../report.json
```

## Why

Live-fire dogfooding on FactSpark (14 real runs) surfaced this — every run produced the same failure on the same step/scorer combo, but the summary gave no hint of that clustering. An adopter would assume their pipeline was broken in 14 different ways, when in reality it was one issue manifesting 14 times.

## Behavior

- **Cluster line shown** when more than one failure shares the same `(step_id, scorer_name)`.
- **Cluster line suppressed** when failures don't cluster — every singleton would be misleading rather than helpful.
- **Run-level failures** (RunScorer) omit the step_id slash; output is `N of <scorer-name>` instead of `N of <step>/<scorer>`.
- **Reasoning longer than 80 characters** is truncated with `...` to keep the summary single-line.

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run mypy pipewise/` passes
- [x] `uv run pytest` — 414 passed, 1 skipped (LlmJudge real-API)
- [x] New: multi-run cluster surfaces the line
- [x] New: single failure suppresses the line
- [x] New: run-scorer cluster omits step_id slash
- [x] New: long reasoning truncated with ellipsis
- [x] Manual smoke against real FactSpark runs (14 identical failures → expected line)

## CHANGELOG

Added under `[Unreleased]` → `Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)