### PR TITLE
docs(claude): add deterministic-eval architectural commitment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ These rules are load-bearing for the project's positioning. Violating any of the
 - **Adapters live in their pipeline's repo, not in pipewise.** Pipewise's `examples/` directory only links to external adapter implementations.
 - **Pipeline runs are immutable, append-only.** New runs never overwrite old runs. Filenames are timestamped.
 - **Pipewise EVALUATES, does not EXECUTE.** Adapters produce `PipelineRun`s; pipewise reads them and runs scorers. Pipeline execution is out of scope for v1.
+- **Pipewise's eval logic is deterministic, forever.** Same dataset + same scorers = same scores. Reproducibility is the value proposition — measurement is only meaningful when it's stable across runs. Agentic capabilities (diagnosis, optimization, monitoring, planning) live in separate packages that consume pipewise's reports and use pipewise as a tool. The eval framework is the substrate; agents are layered on top, never woven in.
 - **No ChromaDB / no PostgreSQL / no cloud dependency in v1 core.** File-based storage only. Database support is parked.
 - **No telemetry.** Pipewise does not phone home, ever.
 


### PR DESCRIPTION
## Summary

Add a new architectural non-negotiable to \`CLAUDE.md\`:

> **Pipewise's eval logic is deterministic, forever.** Same dataset + same scorers = same scores. Reproducibility is the value proposition — measurement is only meaningful when it's stable across runs. Agentic capabilities (diagnosis, optimization, monitoring, planning) live in separate packages that consume pipewise's reports and use pipewise as a tool. The eval framework is the substrate; agents are layered on top, never woven in.

## Why

This captures a load-bearing architectural decision that's been implicit since v0.0.1 but isn't explicitly committed anywhere. The rule has two practical implications:

1. **Eval logic stays deterministic.** No LLM-judge variance leaking into the eval engine itself; no implicit model upgrades shifting baselines; no \"the runner picked a different rubric this time\" surprises. A scorer that produces 0.83 today will produce 0.83 tomorrow given the same inputs.

2. **Agentic tooling layers on top.** Future tooling around pipewise (e.g., agents that read pipewise reports and propose remediations) ships as separate packages that consume pipewise reports — pipewise itself never grows agency. This keeps adopter trust in the reports as durable artifacts.

The rule sits in Architectural Non-Negotiables alongside \"Adapter pattern is sacred\" and \"Pipewise EVALUATES, does not EXECUTE\" because it's a similarly load-bearing constraint — violating it would erode the project's positioning the same way violating those would.

## Test plan

- [x] \`ruff format --check\` passes (no source changes)
- [x] Privacy hooks pass on commit + push
- [x] CLAUDE.md renders correctly with the new bullet positioned between EVALUATES-not-EXECUTES and the storage/no-telemetry rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)