### PR TITLE
docs(core): replace pipeline-specific examples with neutral identifiers in API docstrings

### DIFF
--- a/pipewise/core/schema.py
+++ b/pipewise/core/schema.py
@@ -7,7 +7,7 @@ Pipeline definitions can be DAGs with branches and conditional steps, but a
 single run is always a linear "what actually happened." Branches are captured
 by which `step_id` was executed; skipped steps are recorded with
 `status="skipped"`. This keeps the schema small while still expressing both
-linear (FactSpark-shape) and branching (resume-tailor-shape) pipelines.
+linear and branching pipelines.
 
 Design rationale and locked decisions are tracked in the project's internal
 plan + decisions log.
@@ -141,7 +141,7 @@ class PipelineRun(BaseModel):
     """
 
     pipeline_name: str = Field(min_length=1)
-    """Stable name for the pipeline (e.g., "factspark", "resume-tailor")."""
+    """Stable name for the pipeline (e.g., "news-analysis", "support-triage")."""
 
     pipeline_version: str | None = None
     """Semver of the pipeline definition (your prompts), if versioned."""

--- a/pipewise/core/schema.py
+++ b/pipewise/core/schema.py
@@ -82,7 +82,7 @@ class StepExecution(BaseModel):
     error: str | None = None
 
     executor: str | None = None
-    """Agent / skill / script name that ran this step (e.g., "stupid-meter")."""
+    """Agent / skill / script name that ran this step (e.g., "quality-check")."""
 
     model: str | None = None
     """Model identifier (e.g., "claude-opus-4-7", "gemini-3.1-pro")."""

--- a/pipewise/scorers/numeric_tolerance.py
+++ b/pipewise/scorers/numeric_tolerance.py
@@ -1,8 +1,8 @@
 """NumericToleranceScorer — pass when |actual - expected| ≤ tolerance.
 
-Direct example: a `confidence_score` field that drifts by ~15 points after
-upstream prompt changes; `NumericToleranceScorer(field=..., tolerance=10)`
-catches the regression on the next CI run.
+Direct example: if a `confidence_score` field drifts by ~15 points after
+upstream prompt changes, `NumericToleranceScorer(field="confidence_score",
+tolerance=10)` catches the regression on the next CI run.
 
 Two modes:
 - absolute (default): pass iff `|actual - expected| <= tolerance`

--- a/pipewise/scorers/numeric_tolerance.py
+++ b/pipewise/scorers/numeric_tolerance.py
@@ -1,8 +1,8 @@
 """NumericToleranceScorer — pass when |actual - expected| ≤ tolerance.
 
-Direct example: FactSpark's `stupidity_rating` shifts by ~15 points across
-articles after upstream prompt changes; `NumericToleranceScorer(field=...,
-tolerance=10)` would catch that regression on the next CI run.
+Direct example: a `confidence_score` field that drifts by ~15 points after
+upstream prompt changes; `NumericToleranceScorer(field=..., tolerance=10)`
+catches the regression on the next CI run.
 
 Two modes:
 - absolute (default): pass iff `|actual - expected| <= tolerance`


### PR DESCRIPTION
## Summary

Two API-surface docstring examples were tied to a specific consumer pipeline's field/executor names. These appear in \`help(StepExecution)\` and IDE tooltips — permanent in the public API surface — and a generic example serves the same teaching purpose without coupling pipewise's docstrings to one pipeline's data model.

- \`pipewise/core/schema.py:85\` — \`StepExecution.executor\` example string swapped from a pipeline-specific name to a generic \`\"quality-check\"\`.
- \`pipewise/scorers/numeric_tolerance.py:1-5\` — module docstring rewritten to use a generic \`confidence_score\` field instead of a specific pipeline's field name. The "shifts by ~15 points after upstream prompt changes" shape is preserved because that detail teaches the regression-detection use case that \`NumericToleranceScorer\` exists for; only the field name itself is generic-ized.

## Why

Public API docstrings are durable surface — they show up in IDE tooltips, \`help()\` output, and (when generated) hosted API reference pages. Generic examples teach the same concepts without binding pipewise's docs to a specific consumer pipeline's vocabulary. Adopters thinking about \`NumericToleranceScorer\` understand "drift detection on a confidence_score" naturally; the previous wording presupposed familiarity with one specific pipeline that they might not have.

## Test plan

- [x] \`ruff format --check\` clean (59 files unchanged)
- [x] \`ruff check\` clean
- [x] \`mypy pipewise/\` clean (25 source files)
- [x] \`pytest -q\` — 452 passed, 1 skipped (LlmJudge real-API test, opt-in via ANTHROPIC_API_KEY — same skip count as main)
- [x] No behavior change; docstrings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)