### PR TITLE
docs(core): generic-ize pipeline-specific examples in CLI help + core docstrings

### DIFF
--- a/pipewise/cli.py
+++ b/pipewise/cli.py
@@ -131,7 +131,7 @@ def eval_cmd(
         str | None,
         typer.Option(
             "--adapter",
-            help="Module path of the adapter (e.g. 'factspark.integrations.pipewise.adapter'). "
+            help="Module path of the adapter (e.g. 'news_analysis_pipewise.adapter'). "
             "Required unless --scorers <toml> is supplied.",
         ),
     ] = None,

--- a/pipewise/core/report.py
+++ b/pipewise/core/report.py
@@ -98,8 +98,8 @@ class EvalReport(BaseModel):
 
     dataset_name: str | None = None
     """Human-readable name of the dataset that was evaluated, if any
-    (e.g., `"factspark-golden-v1"`). Optional — ad-hoc evals may not have
-    a named dataset."""
+    (e.g., `"news-analysis-golden-v1"`). Optional — ad-hoc evals may not
+    have a named dataset."""
 
     scorer_names: list[str] = Field(default_factory=list)
     """All scorer names that were invoked across this eval. Snapshotted

--- a/pipewise/runner/adapter.py
+++ b/pipewise/runner/adapter.py
@@ -45,8 +45,8 @@ def resolve_adapter(name: str) -> AdapterCallable:
 
     Args:
         name: A dotted Python module path, e.g.
-            ``"factspark.integrations.pipewise.adapter"``. The module must
-            be importable from the current Python environment (installed
+            ``"news_analysis_pipewise.adapter"``. The module must be
+            importable from the current Python environment (installed
             package, in `PYTHONPATH`, etc.).
 
     Returns:


### PR DESCRIPTION
## Summary

Same class of fix as #72. Three additional API-surface docstring examples were tied to a specific consumer pipeline's adapter module path and dataset naming. They surface in `pipewise eval --help`, `help(EvalReport)`, and `help(resolve_adapter)` — permanent in the public API surface — and a generic example serves the same teaching purpose.

- `pipewise/cli.py:134` — `eval_cmd`'s `--adapter` help-text example.
- `pipewise/core/report.py:101` — `EvalReport.dataset_name` field docstring example.
- `pipewise/runner/adapter.py:48` — `resolve_adapter` `name` arg docstring example.

The original cleanup inventory grepped for schema field names (`stupidity_rating`, `article_body`, etc.) and missed these — they only surface under a broader grep that also targets `factspark` / `resume-tailor` literal strings. Independent of #73 (`docs/scorers.md`), so it can land in either order.

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run mypy pipewise/` passes
- [x] `uv run pytest -q` — 452 passed, 1 skipped (LLM judge needing API key, expected)
- [x] No behavior change — only docstring/help-text wording.