### PR TITLE
docs(tests, gha): replace pipeline-specific identifiers in test fixtures + GitHub Action

### DIFF
--- a/.github/actions/pipewise-eval/README.md
+++ b/.github/actions/pipewise-eval/README.md
@@ -24,7 +24,7 @@ The two-step pattern in your CI:
 |---|---|---|---|
 | `report-path` | yes | — | Path to the `EvalReport` JSON for this PR. |
 | `baseline-report-path` | no | `''` | Path to the baseline `EvalReport` JSON. If omitted or the file is missing, the comment shows absolute values with no Δ column. |
-| `adapter-name` | yes | — | Adapter package name (e.g. `factspark_pipewise`). Also the sticky-comment marker key — multi-adapter repos get one comment per adapter. |
+| `adapter-name` | yes | — | Adapter package name (e.g. `news_analysis_pipewise`). Also the sticky-comment marker key — multi-adapter repos get one comment per adapter. |
 | `github-token` | yes | — | Token with `pull-requests: write` permission. Default `GITHUB_TOKEN` is fine. |
 | `python-version` | no | `'3.11'` | Python version used to run the renderer. |
 
@@ -125,8 +125,8 @@ Each call manages its own sticky comment.
 See [`pipewise/ci/github_action.py`](../../../pipewise/ci/github_action.py) and the unit tests in [`tests/ci/test_github_action.py`](../../../tests/ci/test_github_action.py) for the full rendered shape. At a glance:
 
 ```markdown
-<!-- pipewise-eval-report:factspark_pipewise -->
-## Pipewise eval report — factspark_pipewise
+<!-- pipewise-eval-report:news_analysis_pipewise -->
+## Pipewise eval report — news_analysis_pipewise
 
 ✅ All scorers passing · 2 improvements 🟢
 

--- a/.github/actions/pipewise-eval/action.yml
+++ b/.github/actions/pipewise-eval/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: ''
   adapter-name:
     description: |
-      Adapter package name (e.g. `factspark_pipewise`). Used as the
+      Adapter package name (e.g. `news_analysis_pipewise`). Used as the
       sticky-comment marker key so multi-adapter repos can post one
       comment per adapter without clobbering. Also shown in the comment
       header.

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -44,8 +44,8 @@ def _build_report(
         runs=[
             RunEvalResult(
                 run_id=run_id,
-                pipeline_name="factspark",
-                adapter_name="factspark_pipewise",
+                pipeline_name="news-analysis",
+                adapter_name="news_analysis_pipewise",
                 adapter_version="0.0.1",
                 step_scores=[
                     StepScoreEntry(
@@ -77,7 +77,7 @@ class TestCliInProcess:
                 "--report",
                 str(report_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc1234",
                 "--output",
@@ -88,8 +88,8 @@ class TestCliInProcess:
         assert rc == 0
         assert output_path.exists()
         content = output_path.read_text(encoding="utf-8")
-        assert content.startswith("<!-- pipewise-eval-report:factspark -->")
-        assert "## Pipewise eval report — factspark" in content
+        assert content.startswith("<!-- pipewise-eval-report:news-analysis -->")
+        assert "## Pipewise eval report — news-analysis" in content
         assert "<sub>Updated for `abc1234`" in content
 
     def test_no_baseline_path_renders_no_diff_comment(self, tmp_path: Path) -> None:
@@ -102,7 +102,7 @@ class TestCliInProcess:
                 "--report",
                 str(report_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",
@@ -129,7 +129,7 @@ class TestCliInProcess:
                 "--baseline",
                 str(baseline_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",
@@ -163,7 +163,7 @@ class TestCliInProcess:
                 "--baseline",
                 str(baseline_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",
@@ -187,7 +187,7 @@ class TestCliInProcess:
                 "--report",
                 str(report_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",
@@ -215,7 +215,7 @@ class TestCliInProcess:
                     "--report",
                     str(report_path),
                     "--adapter-name",
-                    "factspark",
+                    "news-analysis",
                     "--short-sha",
                     "abc",
                     "--output",
@@ -237,7 +237,7 @@ class TestCliInProcess:
                 "--report",
                 str(missing_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",
@@ -268,7 +268,7 @@ class TestCliInProcess:
                 "--baseline",
                 str(baseline_dir),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",
@@ -305,7 +305,7 @@ class TestCliSubprocess:
                 "--report",
                 str(report_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "deadbee",
                 "--output",
@@ -318,7 +318,7 @@ class TestCliSubprocess:
 
         assert result.returncode == 0, result.stderr
         content = output_path.read_text(encoding="utf-8")
-        assert content.startswith("<!-- pipewise-eval-report:factspark -->")
+        assert content.startswith("<!-- pipewise-eval-report:news-analysis -->")
         assert "<sub>Updated for `deadbee`" in content
 
     def test_module_run_help_flag_succeeds(self) -> None:
@@ -359,7 +359,7 @@ class TestReportRoundTrip:
                 "--report",
                 str(report_path),
                 "--adapter-name",
-                "factspark",
+                "news-analysis",
                 "--short-sha",
                 "abc",
                 "--output",

--- a/tests/ci/test_github_action.py
+++ b/tests/ci/test_github_action.py
@@ -51,8 +51,8 @@ def _run(
 ) -> RunEvalResult:
     return RunEvalResult(
         run_id=run_id,
-        pipeline_name="factspark",
-        adapter_name="factspark_pipewise",
+        pipeline_name="news-analysis",
+        adapter_name="news_analysis_pipewise",
         adapter_version="0.0.1",
         step_scores=step_scores or [],
         run_scores=run_scores or [],
@@ -91,14 +91,14 @@ class TestPassingNoChange:
     def test_verdict_says_no_change(self) -> None:
         baseline, report = self._identical_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc1234"
         )
         assert "✅ All scorers passing · no change vs main" in out
 
     def test_delta_column_shows_dash_for_unchanged(self) -> None:
         baseline, report = self._identical_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc1234"
         )
         # Three rollup rows; each Δ cell should be the em-dash placeholder.
         # Match `| — |` at line ends (the trailing pipe of the Δ column).
@@ -107,7 +107,7 @@ class TestPassingNoChange:
     def test_counts_show_zero_regressions_zero_improvements(self) -> None:
         baseline, report = self._identical_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc1234"
         )
         assert "**Regressions:** 0 🔴" in out
         assert "**Improvements:** 0 🟢" in out
@@ -116,7 +116,7 @@ class TestPassingNoChange:
     def test_no_newly_failing_section_when_no_regressions(self) -> None:
         baseline, report = self._identical_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc1234"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc1234"
         )
         assert "Newly failing checks" not in out
 
@@ -156,14 +156,14 @@ class TestPassingWithImprovements:
     def test_verdict_announces_improvements(self) -> None:
         baseline, report = self._improved_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="def5678"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="def5678"
         )
         assert "✅ All scorers passing · 2 improvements 🟢" in out
 
     def test_delta_column_shows_signed_positives(self) -> None:
         baseline, report = self._improved_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="def5678"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="def5678"
         )
         assert "+0.57 🟢" in out  # 0.97 - 0.40
         assert "+0.46 🟢" in out  # 0.91 - 0.45
@@ -171,7 +171,7 @@ class TestPassingWithImprovements:
     def test_counts_show_two_improvements_one_unchanged(self) -> None:
         baseline, report = self._improved_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="def5678"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="def5678"
         )
         assert "**Regressions:** 0 🔴" in out
         assert "**Improvements:** 2 🟢" in out
@@ -213,15 +213,15 @@ class TestRegressing:
     def test_verdict_announces_regressions(self) -> None:
         baseline, report = self._regressed_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="9abc012"
         )
-        assert out.startswith("<!-- pipewise-eval-report:factspark -->")
+        assert out.startswith("<!-- pipewise-eval-report:news-analysis -->")
         assert "❌ 1 regression · was passing on main, failing here" in out
 
     def test_delta_column_shows_signed_negatives_with_red_emoji(self) -> None:
         baseline, report = self._regressed_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="9abc012"
         )
         assert "-0.55 🔴" in out  # 0.45 - 1.00 (the regression)
         assert "-0.13 🔴" in out  # 0.81 - 0.94 (score delta)
@@ -230,7 +230,7 @@ class TestRegressing:
     def test_newly_failing_section_lists_regression_with_run_id(self) -> None:
         baseline, report = self._regressed_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="9abc012"
         )
         assert "<details><summary><b>Newly failing checks (1)</b></summary>" in out
         assert "`Regex` × `format`" in out
@@ -240,7 +240,7 @@ class TestRegressing:
     def test_counts_show_one_regression(self) -> None:
         baseline, report = self._regressed_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="9abc012"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="9abc012"
         )
         assert "**Regressions:** 1 🔴" in out
         assert "**Improvements:** 0 🟢" in out
@@ -259,7 +259,7 @@ class TestNoBaseline:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc1234")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc1234")
         assert "🆕 1 run · 1/1 scorers passing · no baseline" in out
 
     def test_no_counts_row_when_baseline_missing(self) -> None:
@@ -271,7 +271,7 @@ class TestNoBaseline:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc1234")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc1234")
         # Counts row only renders with a baseline.
         assert "**Regressions:**" not in out
         assert "**Improvements:**" not in out
@@ -285,7 +285,7 @@ class TestNoBaseline:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc1234")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc1234")
         # Main column should be `—` and Δ column should be `—`.
         assert "| — | 0.94 | — |" in out
 
@@ -308,12 +308,12 @@ class TestStructure:
 
     def test_h2_header_includes_adapter_name(self) -> None:
         report = _report(runs=[_run(run_id="r1")])
-        out = render_pr_comment(report, adapter_name="resume_tailor", short_sha="abc")
-        assert "## Pipewise eval report — resume_tailor" in out
+        out = render_pr_comment(report, adapter_name="branching_pipeline", short_sha="abc")
+        assert "## Pipewise eval report — branching_pipeline" in out
 
     def test_short_sha_appears_in_footer(self) -> None:
         report = _report(runs=[_run(run_id="r1")])
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="deadbee")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="deadbee")
         assert "<sub>Updated for `deadbee` ·" in out
 
     def test_run_level_scorers_appear_with_run_level_label(self) -> None:
@@ -325,7 +325,7 @@ class TestStructure:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         assert "`CostBudget` (run-level)" in out
 
     def test_rollup_header_uses_right_aligned_separators(self) -> None:
@@ -337,7 +337,7 @@ class TestStructure:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         # Right-aligned numeric columns per the locked design spec.
         assert "| :--- | ---: | ---: | ---: |" in out
 
@@ -359,7 +359,7 @@ class TestStructure:
                 ),
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         assert "<summary>Full report (2 runs · dataset: golden.jsonl)</summary>" in out
         assert "`run_a` | `s1` | `ExactMatch`" in out
         assert "`run_a` | `s2` | `Regex`" in out
@@ -370,18 +370,18 @@ class TestStructure:
 
     def test_output_ends_with_single_trailing_newline(self) -> None:
         report = _report(runs=[_run(run_id="r1")])
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         assert out.endswith("\n")
         assert not out.endswith("\n\n")
 
     def test_dataset_name_falls_back_to_dash_when_missing(self) -> None:
         report = _report(runs=[_run(run_id="r1")], dataset_name=None)
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         assert "dataset: —" in out
 
     def test_empty_report_renders_gracefully(self) -> None:
         report = _report(runs=[])
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         # No table rows but header + placeholder still renders.
         assert "_No scorer results in this report._" in out
         assert "_No runs in this report._" in out
@@ -432,7 +432,7 @@ class TestFloatingPointPrecision:
         # not be exactly 0 in float. Average baseline = 0.7; average report =
         # (0.1 + 1.0 + 1.0) / 3 = 0.7 (with possible precision noise).
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         # The Δ cell should be "—" (not "+0.00 🟢" or similar).
         assert "+0.00 🟢" not in out
@@ -466,7 +466,7 @@ class TestScoreDeltasWithoutFlips:
     def test_verdict_says_no_regressions_not_no_change(self) -> None:
         baseline, report = self._score_delta_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         # Score moved up but didn't flip pass status. We don't claim "no
         # change" because the rollup table will show a non-zero Δ.
@@ -476,7 +476,7 @@ class TestScoreDeltasWithoutFlips:
     def test_extras_footnote_lists_score_deltas(self) -> None:
         baseline, report = self._score_delta_pair()
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "_Plus: 1 score delta._" in out
 
@@ -504,7 +504,7 @@ class TestExtrasFootnote:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "_Plus: 1 newly added._" in out
 
@@ -529,7 +529,7 @@ class TestExtrasFootnote:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "_Plus: 1 removed._" in out
 
@@ -540,7 +540,7 @@ class TestExtrasFootnote:
         baseline = _report(runs=[_run(run_id="r1", step_scores=run_steps)])
         report = _report(runs=[_run(run_id="r1", step_scores=list(run_steps))])
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "_Plus:" not in out
 
@@ -568,7 +568,7 @@ class TestFailingButNoRegressions:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "⚠️ 1 failing scorer · no regressions vs main" in out
 
@@ -591,7 +591,7 @@ class TestSkippedVerdicts:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         assert "⏭ All scorers skipped · no signal" in out
 
     def test_all_skipped_says_no_signal_with_baseline(self) -> None:
@@ -603,7 +603,7 @@ class TestSkippedVerdicts:
         )
         report = _report(runs=[_run(run_id="r1", step_scores=[_skipped_step_entry("a", "Regex")])])
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "⏭ All scorers skipped · no signal" in out
 
@@ -634,7 +634,7 @@ class TestSkippedVerdicts:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "⏭ 1 newly-skipped scorer · no regressions vs main" in out
 
@@ -665,7 +665,7 @@ class TestSkippedVerdicts:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "✅ All non-skipped scorers passing" in out
 
@@ -681,7 +681,7 @@ class TestSkippedVerdicts:
                 )
             ]
         )
-        out = render_pr_comment(report, adapter_name="factspark", short_sha="abc")
+        out = render_pr_comment(report, adapter_name="news-analysis", short_sha="abc")
         # 1 passing of 2 total; (1 skipped) annotation included.
         assert "1/2 scorers passing (1 skipped)" in out
 
@@ -712,7 +712,7 @@ class TestSkippedVerdicts:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         assert "1 newly skipped" in out
         assert "1 newly running" in out
@@ -745,7 +745,7 @@ class TestSkippedVerdicts:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         # Only r1's single entry is genuinely unchanged. r2's two entries
         # are from a new run; counting them as "unchanged" would be a lie.
@@ -778,7 +778,7 @@ class TestSkippedVerdicts:
             ]
         )
         out = render_pr_comment(
-            report, baseline=baseline, adapter_name="factspark", short_sha="abc"
+            report, baseline=baseline, adapter_name="news-analysis", short_sha="abc"
         )
         # Only 2 are truly unchanged; the third is a transition.
         assert "**Unchanged:** 2" in out

--- a/tests/cli/test_eval_cmd.py
+++ b/tests/cli/test_eval_cmd.py
@@ -2,7 +2,7 @@
 
 Wires CLI → adapter resolver → dataset loader → scorer config / defaults →
 runner → storage. Each test uses a synthetic in-memory adapter module so we
-don't depend on the FactSpark or resume reference adapters being installed.
+don't depend on any specific reference adapter being installed.
 """
 
 from __future__ import annotations
@@ -457,7 +457,7 @@ class TestEvalCommand:
     def test_dataset_name_defaults_to_filename_stem(
         self, tmp_path: Path, adapter_with_defaults: str
     ) -> None:
-        dataset = tmp_path / "factspark-golden.jsonl"
+        dataset = tmp_path / "news-analysis-golden.jsonl"
         _write_dataset(dataset, [_make_run("run_1")])
         output_root = tmp_path / "reports"
 
@@ -476,4 +476,4 @@ class TestEvalCommand:
 
         assert result.exit_code == 0
         subdir = next(output_root.iterdir())
-        assert subdir.name.endswith("_factspark-golden")
+        assert subdir.name.endswith("_news-analysis-golden")

--- a/tests/core/test_report.py
+++ b/tests/core/test_report.py
@@ -299,7 +299,7 @@ class TestEvalReport:
 
     def test_round_trip_json(self) -> None:
         report = self._report(
-            dataset_name="factspark-golden-v1",
+            dataset_name="news-analysis-golden-v1",
             scorer_names=["exact_match", "cost_budget"],
             runs=[
                 self._run_result(

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -2,9 +2,9 @@
 
 Validates the schema's contract — required fields, enum constraints, non-negative
 numeric constraints, datetime tz policy, extra-field policy, round-trip JSON +
-dict serialization, and expressiveness against the two reference pipeline shapes
-(FactSpark linear, resume-tailor branching) — without requiring access to either
-reference pipeline's actual data.
+dict serialization, and expressiveness against the two canonical pipeline shapes
+(linear and branching) — without requiring access to any reference pipeline's
+actual data.
 
 The "validates against real JSON" gates live in issues #6 and #7.
 """
@@ -55,7 +55,7 @@ class TestStepExecution:
             completed_at=NOW + timedelta(seconds=2),
             status="completed",
             error=None,
-            executor="analyze-article",
+            executor="analyze",
             model="claude-opus-4-7",
             provider="anthropic",
             inputs={"url": "https://example.com"},
@@ -66,7 +66,7 @@ class TestStepExecution:
             latency_ms=1500,
             metadata={"adapter_specific": "value"},
         )
-        assert step.executor == "analyze-article"
+        assert step.executor == "analyze"
         assert step.cost_usd == 0.01
         assert step.outputs["nested"]["deep"] == [1, 2, 3]
 
@@ -428,20 +428,20 @@ class TestPipelineRun:
         restored = PipelineRun.model_validate(as_dict)
         assert restored == run
 
-    def test_factspark_shape_round_trips(self) -> None:
-        """The schema can express FactSpark's actual run shape:
-        7 linear steps, all-Claude except step 7 (Gemini), JSON outputs.
+    def test_linear_pipeline_shape_round_trips(self) -> None:
+        """The schema can express a linear pipeline's run shape:
+        7 sequential steps, mixed providers (Anthropic + Google), JSON outputs.
 
-        Shape test only — programmatically constructed, not reading real
-        FactSpark JSON. The real-data gate lives in #6.
+        Shape test only — programmatically constructed. The real-data gate
+        lives in #6.
         """
         step_specs: list[tuple[str, str, str, str]] = [
-            ("analyze", "analyze-article", "claude-opus-4-7", "anthropic"),
-            ("enhance_entities", "enhance-entities-geographic", "claude-opus-4-7", "anthropic"),
-            ("enhance_content", "enhance-content-assessment", "claude-opus-4-7", "anthropic"),
-            ("enhance_source", "enhance-source-temporal", "claude-opus-4-7", "anthropic"),
-            ("stupid_meter", "stupid-meter", "claude-opus-4-7", "anthropic"),
-            ("enhance_analytics_ui", "enhance-analytics-ui", "claude-opus-4-7", "anthropic"),
+            ("analyze", "analyze", "claude-opus-4-7", "anthropic"),
+            ("enhance_entities", "enhance-entities", "claude-opus-4-7", "anthropic"),
+            ("enhance_content", "enhance-content", "claude-opus-4-7", "anthropic"),
+            ("enhance_source", "enhance-source", "claude-opus-4-7", "anthropic"),
+            ("quality_check", "quality-check", "claude-opus-4-7", "anthropic"),
+            ("enhance_analytics", "enhance-analytics", "claude-opus-4-7", "anthropic"),
             ("verify_claims", "verify-claims", "gemini-3.1-pro", "google"),
         ]
         steps = [
@@ -459,14 +459,14 @@ class TestPipelineRun:
             for i, (sid, executor, model, provider) in enumerate(step_specs)
         ]
         run = PipelineRun(
-            run_id="bbc_trump_tariffs_supreme_court_20260224",
-            pipeline_name="factspark",
+            run_id="news-sample-001-20260224",
+            pipeline_name="news-analysis",
             started_at=NOW,
             completed_at=NOW + timedelta(seconds=10),
             status="completed",
             initial_input={"url": "https://...", "title": "..."},
             steps=steps,
-            adapter_name="factspark-pipewise-adapter",
+            adapter_name="news-analysis-pipewise-adapter",
             adapter_version="0.1.0",
         )
         restored = PipelineRun.model_validate_json(run.model_dump_json())
@@ -474,45 +474,45 @@ class TestPipelineRun:
         assert restored.steps[-1].provider == "google"
         assert all(s.provider == "anthropic" for s in restored.steps[:-1])
 
-    def test_resume_branching_shape_round_trips(self) -> None:
-        """The schema can express the harder resume-tailor pipeline:
+    def test_branching_pipeline_shape_round_trips(self) -> None:
+        """The schema can express a branching pipeline:
         - Step 2 was skipped (status="skipped", no completed_at)
-        - Step 4b ran, not Step 4 (branch captured by step_id)
+        - Step 4 ran in its branch_b variant, not branch_a
         - Step 7 absent (gated off by step 5 status)
 
         Shape test only — real-data gate is #7.
         """
         steps = [
-            _step("analyze_posting"),
-            _step("discovery", status="skipped"),
-            _step("research_company"),
-            _step("write_resume_hybrid"),  # branch chosen, not "write_resume"
-            _step("critique"),
+            _step("step_1"),
+            _step("step_2", status="skipped"),
+            _step("step_3"),
+            _step("step_4_branch_b"),  # branch chosen, not "step_4_branch_a"
+            _step("step_5"),
             StepExecution(
-                step_id="format_export",
-                step_name="Format & Export",
+                step_id="step_6",
+                step_name="Step 6",
                 started_at=NOW,
                 completed_at=NOW + timedelta(seconds=1),
                 status="completed",
-                outputs={"format": "markdown", "ats_risk": "MODERATE"},
+                outputs={"format": "markdown", "quality": "MODERATE"},
             ),
-            # step "export_canva" deliberately absent — gated off by step 5
+            # step "step_7" deliberately absent — gated off by step 5
         ]
         run = PipelineRun(
-            run_id="deepintent_senior_program_manager",
-            pipeline_name="resume-tailor",
+            run_id="sample-branching-001",
+            pipeline_name="branching-pipeline",
             started_at=NOW,
             status="partial",  # gated step means run didn't finish cleanly
             steps=steps,
-            adapter_name="resume-tailor-pipewise-adapter",
+            adapter_name="branching-pipeline-pipewise-adapter",
             adapter_version="0.1.0",
         )
         restored = PipelineRun.model_validate_json(run.model_dump_json())
         assert restored == run
         assert any(s.status == "skipped" for s in restored.steps)
-        assert any(s.step_id == "write_resume_hybrid" for s in restored.steps)
-        assert not any(s.step_id == "write_resume" for s in restored.steps)
-        assert not any(s.step_id == "export_canva" for s in restored.steps)
+        assert any(s.step_id == "step_4_branch_b" for s in restored.steps)
+        assert not any(s.step_id == "step_4_branch_a" for s in restored.steps)
+        assert not any(s.step_id == "step_7" for s in restored.steps)
 
 
 class TestSchemaPolicies:

--- a/tests/runner/test_dataset.py
+++ b/tests/runner/test_dataset.py
@@ -17,11 +17,11 @@ NOW = datetime(2026, 4, 27, 12, 0, 0, tzinfo=UTC)
 def _make_run(run_id: str = "run_1") -> dict[str, object]:
     return {
         "run_id": run_id,
-        "pipeline_name": "factspark",
+        "pipeline_name": "news-analysis",
         "started_at": NOW.isoformat(),
         "completed_at": NOW.isoformat(),
         "status": "completed",
-        "adapter_name": "factspark-adapter",
+        "adapter_name": "news-analysis-adapter",
         "adapter_version": "0.1.0",
         "steps": [],
     }

--- a/tests/runner/test_eval.py
+++ b/tests/runner/test_eval.py
@@ -140,9 +140,9 @@ class TestRunEval:
             assert scorers_seen == {"raising-step", "passing-step"}
 
     def test_dataset_name_recorded_in_report(self) -> None:
-        report = run_eval([_run()], [], [], dataset_name="factspark-golden-v1")
-        assert report.dataset_name == "factspark-golden-v1"
-        assert "factspark-golden-v1" in report.report_id
+        report = run_eval([_run()], [], [], dataset_name="news-analysis-golden-v1")
+        assert report.dataset_name == "news-analysis-golden-v1"
+        assert "news-analysis-golden-v1" in report.report_id
 
     def test_dataset_name_omitted_uses_adhoc_label(self) -> None:
         report = run_eval([_run()], [], [])

--- a/tests/runner/test_inspect.py
+++ b/tests/runner/test_inspect.py
@@ -19,12 +19,12 @@ runner = CliRunner()
 def _run(steps: list[StepExecution] | None = None) -> PipelineRun:
     return PipelineRun(
         run_id="run_42",
-        pipeline_name="factspark",
+        pipeline_name="news-analysis",
         pipeline_version="1.2.0",
         started_at=NOW,
         completed_at=NOW + timedelta(seconds=12),
         status="completed",
-        adapter_name="factspark-adapter",
+        adapter_name="news-analysis-adapter",
         adapter_version="0.1.0",
         steps=steps if steps is not None else [],
         total_cost_usd=0.0349,
@@ -41,7 +41,7 @@ def _step(step_id: str = "s1", outputs: dict[str, object] | None = None) -> Step
         started_at=NOW,
         completed_at=NOW + timedelta(seconds=1, milliseconds=500),
         status="completed",
-        executor="stupid-meter",
+        executor="quality-check",
         model="claude-opus-4-7",
         cost_usd=0.0123,
         latency_ms=1500,
@@ -54,15 +54,15 @@ class TestFormatRun:
         out = format_run(_run([_step()]))
         assert "Run:" in out
         assert "run_42" in out
-        assert "factspark@1.2.0" in out
-        assert "factspark-adapter@0.1.0" in out
+        assert "news-analysis@1.2.0" in out
+        assert "news-analysis-adapter@0.1.0" in out
 
     def test_pipeline_id_omits_at_when_no_version(self) -> None:
         run = _run([_step()])
         run = run.model_copy(update={"pipeline_version": None})
         out = format_run(run)
-        assert "factspark@" not in out
-        assert "factspark" in out
+        assert "news-analysis@" not in out
+        assert "news-analysis" in out
 
     def test_lists_steps(self) -> None:
         out = format_run(_run([_step("s1"), _step("s2")]))
@@ -108,18 +108,18 @@ class TestFormatRun:
     def test_keys_mode_renders_top_level_structure(self) -> None:
         # Real-pipeline-shaped step: nested dict + list + scalar.
         outputs = {
-            "article_metadata": {"title": "T", "source": "BBC", "author": "X"},
-            "extracted_claims": [{"id": 1}, {"id": 2}, {"id": 3}],
-            "full_article_content": "lots of text here " * 100,
+            "metadata": {"title": "T", "source": "News Source A", "author": "X"},
+            "extracted_items": [{"id": 1}, {"id": 2}, {"id": 3}],
+            "body_text": "lots of text here " * 100,
             "score": 7,
         }
         out = format_run(_run([_step(outputs=outputs)]), keys=True)
-        assert "'article_metadata': dict[3]" in out
-        assert "'extracted_claims': list[3]" in out
-        assert "'full_article_content': str" in out
+        assert "'metadata': dict[3]" in out
+        assert "'extracted_items': list[3]" in out
+        assert "'body_text': str" in out
         assert "'score': int" in out
         # Values must NOT appear in keys mode.
-        assert "BBC" not in out
+        assert "News Source A" not in out
         assert "lots of text here" not in out
 
     def test_keys_mode_handles_empty_dict(self) -> None:
@@ -172,7 +172,7 @@ class TestInspectCommand:
 
         assert result.exit_code == 0, result.stdout
         assert "run_42" in result.stdout
-        assert "factspark" in result.stdout
+        assert "news-analysis" in result.stdout
 
     def test_inspect_format_json_emits_valid_json_round_trip(self, tmp_path: Path) -> None:
         run = _run([_step()])
@@ -223,7 +223,7 @@ class TestInspectCommand:
 
     def test_inspect_keys_flag_renders_structural_summary(self, tmp_path: Path) -> None:
         outputs = {
-            "article_metadata": {"a": 1, "b": 2, "c": 3},
+            "metadata": {"a": 1, "b": 2, "c": 3},
             "claims": [{"id": 1}, {"id": 2}],
             "score": 42,
         }
@@ -234,7 +234,7 @@ class TestInspectCommand:
         result = runner.invoke(app, ["inspect", str(run_path), "--keys"])
 
         assert result.exit_code == 0, result.stdout
-        assert "'article_metadata': dict[3]" in result.stdout
+        assert "'metadata': dict[3]" in result.stdout
         assert "'claims': list[2]" in result.stdout
         assert "'score': int" in result.stdout
 

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -16,7 +16,7 @@ NOW = datetime(2026, 4, 27, 9, 15, 0, tzinfo=UTC)
 def _report(
     *,
     generated_at: datetime = NOW,
-    dataset_name: str | None = "factspark-golden-v1",
+    dataset_name: str | None = "news-analysis-golden-v1",
     report_id: str | None = None,
 ) -> EvalReport:
     return EvalReport(
@@ -42,7 +42,7 @@ class TestWriteReport:
 
         assert report_path.exists()
         assert report_path.name == "report.json"
-        assert report_path.parent.name == "20260427T091500Z_factspark-golden-v1"
+        assert report_path.parent.name == "20260427T091500Z_news-analysis-golden-v1"
         assert report_path.parent.parent == tmp_path
 
     def test_returned_path_contents_round_trip(self, tmp_path: Path) -> None:
@@ -69,8 +69,8 @@ class TestWriteReport:
         assert first_path != second_path
         assert first_path.parent != second_path.parent
         assert {p.name for p in tmp_path.iterdir()} == {
-            "20260427T091500Z_factspark-golden-v1",
-            "20260427T091600Z_factspark-golden-v1",
+            "20260427T091500Z_news-analysis-golden-v1",
+            "20260427T091600Z_news-analysis-golden-v1",
         }
 
     def test_output_root_is_created_if_missing(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Final cleanup PR in the inline-renaming arc (sibling to #72 / #73 / #74 / #75). The pipewise core / docs / examples are now clean — what remains here is test fixture data and the `pipewise-eval` GitHub Action's adapter-name example.

The replacement archetype is the **news-analysis** pipeline established in earlier PRs (linear) plus a **branching-pipeline** archetype for the schema's branching shape test.

- `tests/runner/test_inspect.py` — fixture pipeline / adapter / executor names + the inputs-keys structural-summary fixture (`metadata` / `extracted_items` / `body_text` / `News Source A`).
- `tests/runner/test_dataset.py`, `test_eval.py`, `test_storage.py`, `tests/core/test_report.py` — `pipeline_name` / `adapter_name` / `dataset_name` fixture strings.
- `tests/cli/test_eval_cmd.py` — module docstring tightened (no longer names specific reference adapters by name) + `dataset_name` filename stem.
- `tests/core/test_schema.py`:
  - Module docstring rewritten ("linear and branching" instead of named pipeline archetypes).
  - `test_factspark_shape_round_trips` → `test_linear_pipeline_shape_round_trips` (executor names cleaned, run_id + pipeline_name + adapter_name generic-ized).
  - `test_resume_branching_shape_round_trips` → `test_branching_pipeline_shape_round_trips` (specific resume-tailor step IDs + run_id replaced with abstract `step_1` ... `step_7` pattern that exercises the same three schema features the original test covered: skipped step, branch chosen, gated-off absent step).
- `tests/ci/test_cli.py`, `tests/ci/test_github_action.py` — `pipeline_name` / `adapter_name` fixture strings + sticky-comment marker assertion strings + the H2-header rendering test's adapter name.
- `.github/actions/pipewise-eval/README.md`, `action.yml` — adapter-name input description's example (`news_analysis_pipewise`) + the comment-format walkthrough's sticky-marker + H2 header lines.

Closes Phase 5.5 step 5.5.3 (the privacy/legal cleanup arc). Remaining FactSpark/resume references live in:

- **Worked-example doc surfaces** (`docs/schema.md`, `docs/adapter-guide.md`, `docs/ci-integration.md`, `examples/README.md`, `README.md`, `CLAUDE.md`) — these get full rewrites in step 5.5.5 around the new reference adapters.
- **Intentional validation-gate test files** in `tests/integration/` — rebuilt in step 5.5.6 against new reference adapters.
- **Historical `CHANGELOG.md` entries** — retained as-is per Keep-a-Changelog convention.

## Test plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run mypy pipewise/` passes
- [x] `uv run pytest -q` — 452 passed, 1 skipped (LLM judge needing API key, expected)
- [x] Verification grep across the repo confirms only deferred-to-5.5.5 / 5.5.6 / historical surfaces remain (full list above)