### PR TITLE
ci: path-filter core CI to skip doc-only + adapter-subdir changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'CLAUDE.md'
+      - '.github/actions/**'
+      - 'examples/langgraph/**'
+      - 'examples/anthropic-quickstarts/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'CLAUDE.md'
+      - '.github/actions/**'
+      - 'examples/langgraph/**'
+      - 'examples/anthropic-quickstarts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

PR E in the 5.5.4 implementation arc — scaffolding work that gates the upcoming reference-adapter PRs.

Adds \`paths-ignore\` to \`ci.yml\` so the core lint/typecheck/test workflow stops firing on PRs that only touch docs, the action README/yml, or the upcoming adapter subpackages at \`examples/langgraph/\` and \`examples/anthropic-quickstarts/\`.

**Why:** the recent cleanup arc (#73, #74, #75) had several PRs with no Python changes that still triggered the full CI matrix. Skipping them cleanly saves CI minutes and keeps PR status pages tidy.

**Future-proofing:** the two \`examples/<adapter>/\` paths are listed pre-emptively. When the adapter directories land in their own PRs, each will bring its own dedicated workflow (\`ci-langgraph.yml\`, \`ci-anthropic-quickstarts.yml\`) — pre-listing them here means those PRs don't have to update this file.

**What still triggers core CI:**
- \`pipewise/**\` (any source change)
- \`tests/**\` (any test change)
- \`pyproject.toml\`, \`uv.lock\` (dep changes)
- \`.github/workflows/ci.yml\` (this file, so workflow changes still get exercised)

**What stops triggering core CI:**
- \`docs/**\`, \`CHANGELOG.md\`, \`README.md\`, \`CLAUDE.md\` (doc-only)
- \`.github/actions/**\` (action README/yml — no Python tests against the action shape)
- \`examples/langgraph/**\`, \`examples/anthropic-quickstarts/**\` (future adapter subpackages)

## Test plan

- [x] YAML syntax valid (manual inspection)
- [ ] Verify CI fires on a Python change (this PR itself touches \`.github/workflows/ci.yml\` so should fire)
- [ ] After merge: doc-only PR (e.g., a future CHANGELOG bump) should NOT fire core CI

## Related

Part of Phase 5.5 step 5.5.4 — the in-tree-subpackages CI strategy decision logged at \`.local/PIVOT_PLAN.md\` §10. Pre-decision #4 in the design walkthrough this session.