### PR TITLE
ci: always fire ci.yml; gate body via dorny/paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,17 @@
 name: CI
 
+# Runs on every PR + push to main. The job body is gated by a path filter
+# so doc-only and adapter-subdir-only changes short-circuit successfully.
+# The workflow always fires (no `paths-ignore`) so required status checks —
+# `lint-typecheck-test (3.11)` and `lint-typecheck-test (3.12)` — pass
+# uniformly even on PRs that don't touch core code. Without this, repo
+# rulesets that require these checks deadlock on doc-only PRs.
+
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'CLAUDE.md'
-      - '.github/actions/**'
-      - 'examples/langgraph/**'
-      - 'examples/anthropic-quickstarts/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'CLAUDE.md'
-      - '.github/actions/**'
-      - 'examples/langgraph/**'
-      - 'examples/anthropic-quickstarts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,25 +28,50 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            core:
+              - 'pipewise/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/ci.yml'
+
+      - name: No core changes — short-circuit (success)
+        if: steps.changes.outputs.core != 'true'
+        run: |
+          echo "::notice::Doc-only / adapter-subdir change; skipping lint/typecheck/test."
+          echo "::notice::Required status checks still report success so branch protection isn't deadlocked."
+
       - name: Install uv
+        if: steps.changes.outputs.core == 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python ${{ matrix.python-version }}
+        if: steps.changes.outputs.core == 'true'
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
+        if: steps.changes.outputs.core == 'true'
         run: uv sync --all-extras --dev
 
       - name: Lint (ruff)
+        if: steps.changes.outputs.core == 'true'
         run: uv run ruff check .
 
       - name: Format check (ruff)
+        if: steps.changes.outputs.core == 'true'
         run: uv run ruff format --check .
 
       - name: Type check (mypy)
+        if: steps.changes.outputs.core == 'true'
         run: uv run mypy pipewise/
 
       - name: Test (pytest)
+        if: steps.changes.outputs.core == 'true'
         run: uv run pytest -ra


### PR DESCRIPTION
## Summary

Unblocks doc-only PRs (e.g., #84) by switching `ci.yml` from `paths-ignore` (skip workflow → check never reports → required-check deadlock) to "always-fire workflow, gate the job body via `dorny/paths-filter`."

## Why

The repo ruleset on `main` requires `lint-typecheck-test (3.11)` and `lint-typecheck-test (3.12)` to pass before merge. PR #77 added `paths-ignore` so doc-only and adapter-subdir PRs would skip core CI — but a required check that never fires can't pass, so doc-only PRs deadlock with `mergeStateStatus: BLOCKED` (#84 hit this exact case today).

This is the open architectural ambiguity #3 flagged in PR #77's body and carried forward in the 2026-05-01 session handoffs.

## What changed

- Removes `paths-ignore` from the workflow trigger.
- Adds a `dorny/paths-filter@v3` step that detects whether **core** paths changed: `pipewise/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `.github/workflows/ci.yml`.
- Each subsequent step is `if: steps.changes.outputs.core == 'true'` — they only run when core paths actually changed.
- A noop "short-circuit" step runs on non-core changes so the job reports success cleanly.

## Why allowlist instead of denylist

The previous `paths-ignore` denylist (`docs/**`, `CHANGELOG.md`, `README.md`, `CLAUDE.md`, `.github/actions/**`, `examples/<framework>/**`) is maintenance-prone — every new doc-shaped path needs a new entry, and it's easy to drift. The new `core` allowlist is small and explicit; new top-level paths default to "no CI" until they're added.

## Behavior matrix

| PR shape | Old behavior | New behavior |
|---|---|---|
| Doc-only (#84-style) | Workflow skipped → required check missing → BLOCKED | Workflow fires, both matrix jobs short-circuit in <30s, checks report green, mergeable |
| Core change | Full lint/format/mypy/pytest | Full lint/format/mypy/pytest (unchanged) |
| Adapter-subdir only | Workflow skipped (adapter-specific workflow handles) | Workflow fires + short-circuits; adapter workflow runs (unchanged) |

## Test plan

- [x] Confirmed ruleset requires `lint-typecheck-test (3.11)` and `lint-typecheck-test (3.12)`.
- [x] PR #84 (docs/schema) currently `mergeStateStatus: BLOCKED` — will rebase after this merges to confirm it becomes `CLEAN`.
- [ ] CI on this PR runs full lint/typecheck/test (this PR touches `.github/workflows/ci.yml`, which is in the `core` filter — full run is expected and verifies the workflow doesn't break itself).
- [ ] After merge, rebase #84 and confirm `lint-typecheck-test (3.11)` and `(3.12)` both report green via short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)