### PR TITLE
docs(adapter-guide): rewrite worked examples around reference adapters

### DIFF
--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -195,7 +195,7 @@ The recommended pattern for new adapters is the capture/adapter split. Both refe
 
 `pipewise eval --dataset <path.jsonl>` consumes a JSONL file where **each line is a complete serialized `PipelineRun`** (not a path or pointer). That JSONL is built upstream of pipewise, by your own code, in four steps:
 
-1. **Your pipeline runs** against your dataset of *inputs* and produces some on-disk record of each completed run — either a raw native format (per-step JSON files, log dumps, etc.) or, in the recommended pattern, a complete `PipelineRun` JSON written by a capture primitive (see "Capture vs adapter: run-time / eval-time split" below; both reference adapters take this approach).
+1. **Your pipeline runs** against your dataset of *inputs* and produces some on-disk record of each completed run — either a raw native format (per-step JSON files, log dumps, etc.) or, in the recommended pattern, a complete `PipelineRun` JSON written by a capture primitive (see "Capture vs adapter: run-time / eval-time split" above; both reference adapters take this approach).
 2. **Your runner code calls `adapter.load_run(raw_path)`** for each completed run, getting back a `PipelineRun` object.
 3. **Your runner serializes each `PipelineRun` to one line of JSONL** via `run.model_dump_json()` and writes the lines to your golden dataset file.
 4. **`pipewise eval --dataset golden.jsonl --adapter <module>`** reads the JSONL, validates each row as a `PipelineRun`, and runs your default scorers (or the ones in `--scorers <toml>` if supplied).
@@ -262,7 +262,8 @@ def capture_run(graph, initial_input, *, run_id, pipeline_name,
             n = iteration_counter[node_name]
             seen_nodes.add(node_name)
 
-            new_messages = (state_update or {}).get("messages") or []
+            update = state_update or {}
+            new_messages = (update.get("messages") or []) if isinstance(update, dict) else []
             input_tokens, output_tokens = _extract_usage(new_messages)
 
             captured_at = datetime.now(UTC)
@@ -270,7 +271,7 @@ def capture_run(graph, initial_input, *, run_id, pipeline_name,
                 step_id=f"{node_name}__{n}",
                 step_name=f"{node_name.replace('_', ' ').title()} (iteration {n})",
                 executor=node_name, model=model, provider=provider,
-                inputs={}, outputs=_serialize(state_update),
+                inputs={}, outputs=_serialize(update),
                 started_at=captured_at, completed_at=captured_at,
                 status="completed",
                 input_tokens=input_tokens or None,
@@ -358,6 +359,7 @@ The structurally interesting bit is how capture observes each LLM call and tool 
 # pipewise_anthropic_quickstarts/capture.py — abridged
 from collections import defaultdict
 from datetime import UTC, datetime
+from typing import Any
 import time
 
 from pipewise.core.schema import PipelineRun, StepExecution
@@ -379,7 +381,7 @@ def capture_run(client, user_input, *, run_id, pipeline_name, system,
     iteration_counter: dict[str, int] = defaultdict(int)
     steps: list[StepExecution] = []
 
-    def sink(event_kind: str, event_data: dict) -> None:
+    def sink(event_kind: str, event_data: dict[str, Any]) -> None:
         captured_at = datetime.now(UTC)
         if event_kind == "llm_call":
             response = event_data["response"]

--- a/docs/adapter-guide.md
+++ b/docs/adapter-guide.md
@@ -1,6 +1,6 @@
 # Writing a pipewise adapter
 
-This guide walks through building a pipewise adapter using the two reference integrations as worked examples — a linear-ish 7-step pipeline (FactSpark, news analysis) and a branching/conditional pipeline (resume-tailor). Both adapters are about ~250 lines of Python with full test coverage; you should be able to ship one for your own pipeline in an afternoon.
+This guide walks through building a pipewise adapter using the two reference integrations as worked examples — a declarative-graph agent ([LangGraph](https://langchain-ai.github.io/langgraph/) `create_react_agent`) and an imperative-loop agent ([Anthropic Quickstarts `agents`](https://github.com/anthropics/anthropic-quickstarts/tree/main/agents) shape). Both adapters live in-tree under `examples/<framework>/`, are a few hundred lines of Python with full unit-test coverage, and are designed to be cloned and adapted to your own pipeline in an afternoon.
 
 ## What an adapter does
 
@@ -147,9 +147,11 @@ If both commands succeed, pipewise is installed correctly and the adapter contra
 
 ## Why the adapter lives in your repo, not in pipewise
 
-This is the architectural commitment that makes pipewise's "general framework" claim verifiable. Your pipeline depends on pipewise (via `pip install pipewise`); pipewise has zero knowledge of your pipeline. A reviewer cloning the pipewise repo sees no traces of any specific pipeline in the core code, and the `examples/` directory only links to external adapter implementations.
+This is the architectural commitment that makes pipewise's "general framework" claim verifiable. Your pipeline depends on pipewise (via `pip install pipewise`); pipewise has zero knowledge of your pipeline. A reviewer cloning the pipewise repo sees no traces of any specific pipeline in the core code.
 
 It also keeps the dependency graph clean: pipewise stays small (no optional pipeline-specific extras to maintain), and your pipeline can iterate on its adapter without coordinating releases with pipewise.
+
+The two reference adapters under `examples/<framework>/` are the one carve-out: when the upstream pipeline isn't controlled by the adopter (as with the LangGraph and Anthropic Quickstarts reference adapters), the adapter ships as an in-tree subpackage with its own `pyproject.toml` and dep stack. Pipewise core still doesn't import them; the carve-out gives reference adapters a home for a category of pipeline that wouldn't otherwise have one.
 
 ## The contract
 
@@ -174,13 +176,26 @@ def default_scorers() -> tuple[list[StepScorer], list[RunScorer]]:
     `pipewise eval` invocation must pass `--scorers <toml>` explicitly."""
 ```
 
-`load_run` is required; `default_scorers` is optional. Pipewise's `--adapter` flag accepts a dotted module path (e.g., `--adapter factspark_pipewise.adapter`) and resolves `default_scorers` via `importlib.import_module` at eval time. **Pipewise never calls `load_run` itself** — `load_run` is a helper your own code uses to build the JSONL dataset that pipewise consumes.
+`load_run` is required; `default_scorers` is optional. Pipewise's `--adapter` flag accepts a dotted module path (e.g., `--adapter pipewise_langgraph.adapter`) and resolves `default_scorers` via `importlib.import_module` at eval time. **Pipewise never calls `load_run` itself** — `load_run` is a helper your own code uses to build the JSONL dataset that pipewise consumes.
+
+## Capture vs adapter: the run-time / eval-time split
+
+Both reference adapters split their code into two halves:
+
+- **`capture.py` — run-time.** Wraps your pipeline's invocation, observes each step as it executes, and emits a complete `PipelineRun` JSON to disk. May call LLMs, hit network, depend on the framework SDK, etc.
+- **`adapter.py` — eval-time.** Exposes `load_run` + `default_scorers`. `load_run` is a one-liner: `PipelineRun.model_validate_json(Path(path).read_text(encoding="utf-8"))`. No LLM calls, no network, no framework dependency at eval time.
+
+This split is the simplest way to honor pipewise's determinism rule — same JSON in, same scores out — without making adapter authors think about it. The capture half can be as messy as the underlying framework requires; eval-time stays a deterministic file read.
+
+If your pipeline already writes a native on-disk format you can't change (typical for pre-existing or third-party pipelines), the alternative is to put the translation logic *inside* `load_run` itself, mapping per-step files into a `PipelineRun` at materialization time. This works but blurs the determinism boundary — keep the translation pure (no network, no LLM calls) so re-running materialization on the same inputs produces the same JSON.
+
+The recommended pattern for new adapters is the capture/adapter split. Both reference adapters demonstrate it in detail (`examples/langgraph/pipewise_langgraph/{capture,adapter}.py` and `examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/{capture,adapter}.py`).
 
 ## Where PipelineRun JSONL files come from
 
 `pipewise eval --dataset <path.jsonl>` consumes a JSONL file where **each line is a complete serialized `PipelineRun`** (not a path or pointer). That JSONL is built upstream of pipewise, by your own code, in four steps:
 
-1. **Your pipeline runs** against your dataset of *inputs* and produces raw outputs (e.g., `articles/<id>_step{N}.json` files for FactSpark, or whatever shape your pipeline emits).
+1. **Your pipeline runs** against your dataset of *inputs* and produces some on-disk record of each completed run — either a raw native format (per-step JSON files, log dumps, etc.) or, in the recommended pattern, a complete `PipelineRun` JSON written by a capture primitive (see "Capture vs adapter: run-time / eval-time split" below; both reference adapters take this approach).
 2. **Your runner code calls `adapter.load_run(raw_path)`** for each completed run, getting back a `PipelineRun` object.
 3. **Your runner serializes each `PipelineRun` to one line of JSONL** via `run.model_dump_json()` and writes the lines to your golden dataset file.
 4. **`pipewise eval --dataset golden.jsonl --adapter <module>`** reads the JSONL, validates each row as a `PipelineRun`, and runs your default scorers (or the ones in `--scorers <toml>` if supplied).
@@ -211,158 +226,310 @@ This separation has three useful properties:
 - **`golden.jsonl` is a stable, self-contained artifact.** You can commit it to git, hand it to another tool, or eval it with a future version of pipewise without re-running your pipeline.
 - **`load_run` failures are debuggable in your own code, not buried in pipewise output.** If your adapter raises, it raises in your runner script, with your stack trace — not inside `pipewise eval`.
 
-## Worked example 1 — FactSpark (linear pipeline)
+## Worked example 1 — declarative-graph agent (LangGraph)
 
-FactSpark is a 7-step news-analysis pipeline. Each step writes its output as JSON to `articles/<prefix>_step{N}.json`. Steps 1-6 propagate `full_article_content` forward; step 7 (Gemini-based claim verification) has a totally different output schema.
+The LangGraph reference adapter targets `create_react_agent` — a node-and-edge graph where the runtime alternates between an `agent` node (LLM call) and a `tools` node (parallel tool execution) until the agent stops emitting tool calls. Iteration is part of the schema: a single user input commonly produces `agent__1` → `tools__1` → `agent__2`, and a graph topology node that the run never visits is recorded as `status="skipped"`.
 
-The adapter (~250 LOC at `factspark-app/integrations/pipewise/factspark_pipewise/adapter.py` once that repo flips public alongside pipewise v1.0):
+Lives at [`examples/langgraph/pipewise_langgraph/`](../examples/langgraph/pipewise_langgraph/). Capture handles the run-time mess (graph streaming, message normalization, topology walk for skipped nodes); the eval-time adapter is short enough to read top-to-bottom in one sitting. Below, both halves abridged to focus on the structurally interesting code.
+
+### Capture half
 
 ```python
-# factspark_pipewise/adapter.py — abridged
-_STEP_LINEUP: list[tuple[str, str, str, str]] = [
-    ("analyze",            "analyze-article",            "claude-opus-4-7", "anthropic"),
-    ("enhance_entities",   "enhance-entities-geographic","claude-opus-4-7", "anthropic"),
-    ("enhance_content",    "enhance-content-assessment", "claude-opus-4-7", "anthropic"),
-    ("enhance_source",     "enhance-source-temporal",    "claude-opus-4-7", "anthropic"),
-    ("stupid_meter",       "stupid-meter",               "claude-opus-4-7", "anthropic"),
-    ("enhance_analytics_ui","enhance-analytics-ui",      "claude-opus-4-7", "anthropic"),
-    ("verify_claims",      "verify-claims",              "gemini-3.1-pro",  "google"),
-]
+# pipewise_langgraph/capture.py — abridged
+from collections import defaultdict
+from datetime import UTC, datetime
+import time
 
-def load_run(path: Path) -> PipelineRun:
-    prefix = Path(str(path)).name.removesuffix("_step1.json")
-    articles_dir, step_paths = _find_step_files(prefix)
-    base = datetime.fromtimestamp(step_paths[0].stat().st_mtime, tz=UTC)
+from pipewise.core.schema import PipelineRun, StepExecution
 
+
+def capture_run(graph, initial_input, *, run_id, pipeline_name,
+                pipeline_version="0.1.0", adapter_version="0.1.0",
+                model=None, provider=None) -> PipelineRun:
+    started_at = datetime.now(UTC)
+    t_run_start = time.perf_counter()
+
+    iteration_counter: dict[str, int] = defaultdict(int)
+    seen_nodes: set[str] = set()
     steps: list[StepExecution] = []
-    for i, ((step_id, executor, model, provider), step_path) in enumerate(
-        zip(_STEP_LINEUP, step_paths, strict=True)
-    ):
-        if not step_path.exists():
-            steps.append(StepExecution(
-                step_id=step_id, step_name=step_id.replace("_", " ").title(),
-                started_at=base + timedelta(seconds=i * 10), completed_at=None,
-                status="failed", error=f"step{i + 1}.json missing",
-                executor=executor, model=model, provider=provider,
-            ))
-            continue
-        outputs = json.loads(step_path.read_text(encoding="utf-8"))
-        steps.append(StepExecution(
-            step_id=step_id, step_name=step_id.replace("_", " ").title(),
-            started_at=base + timedelta(seconds=i * 10),
-            completed_at=base + timedelta(seconds=(i * 10) + 5),
-            status="completed", executor=executor, model=model, provider=provider,
-            outputs=outputs,
-        ))
 
+    # Each chunk carries one node's state diff. Node names repeat for iterated
+    # nodes; we suffix with __N (always, even single-fire) so step_ids stay
+    # mechanically uniform and match adopter expectations.
+    for chunk in graph.stream(initial_input, stream_mode="updates"):
+        for node_name, state_update in chunk.items():
+            iteration_counter[node_name] += 1
+            n = iteration_counter[node_name]
+            seen_nodes.add(node_name)
+
+            new_messages = (state_update or {}).get("messages") or []
+            input_tokens, output_tokens = _extract_usage(new_messages)
+
+            captured_at = datetime.now(UTC)
+            steps.append(StepExecution(
+                step_id=f"{node_name}__{n}",
+                step_name=f"{node_name.replace('_', ' ').title()} (iteration {n})",
+                executor=node_name, model=model, provider=provider,
+                inputs={}, outputs=_serialize(state_update),
+                started_at=captured_at, completed_at=captured_at,
+                status="completed",
+                input_tokens=input_tokens or None,
+                output_tokens=output_tokens or None,
+                latency_ms=None,  # stream_mode="updates" fires after node finishes
+            ))
+
+    # Record skipped nodes — every topology node we never saw in the stream.
+    for node_name in _topology_nodes(graph):
+        if node_name not in seen_nodes:
+            steps.append(StepExecution(
+                step_id=f"{node_name}__1",
+                step_name=f"{node_name.replace('_', ' ').title()} (iteration 1)",
+                executor=node_name, model=model, provider=provider,
+                inputs={}, outputs={},
+                started_at=datetime.now(UTC), completed_at=None,
+                status="skipped",
+            ))
+
+    total_latency_ms = int((time.perf_counter() - t_run_start) * 1000)
     return PipelineRun(
-        run_id=prefix, pipeline_name="factspark",
-        started_at=base, completed_at=base + timedelta(seconds=70),
-        status="completed" if all(s.status == "completed" for s in steps) else "partial",
-        steps=steps, final_output=steps[-1].outputs,
-        adapter_name="factspark-pipewise-adapter", adapter_version="0.1.0",
+        run_id=run_id, pipeline_name=pipeline_name,
+        adapter_name="pipewise-langgraph", adapter_version="0.1.0",
+        started_at=started_at, completed_at=datetime.now(UTC),
+        status="completed",
+        initial_input=_serialize(initial_input),
+        steps=steps,
+        total_input_tokens=sum(s.input_tokens or 0 for s in steps) or None,
+        total_output_tokens=sum(s.output_tokens or 0 for s in steps) or None,
+        total_latency_ms=total_latency_ms,
+    )
+```
+
+### Eval-time adapter
+
+```python
+# pipewise_langgraph/adapter.py — full
+from pathlib import Path
+
+from pipewise.core.schema import PipelineRun
+from pipewise.scorers.budget import LatencyBudgetScorer
+from pipewise.scorers.json_schema import JsonSchemaScorer
+
+
+def load_run(path: str | Path) -> PipelineRun:
+    return PipelineRun.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+_LANGGRAPH_OUTPUT_SCHEMA = {
+    "type": "object",
+    "required": ["messages"],
+    "properties": {
+        "messages": {"type": "array", "minItems": 1, "items": {
+            "type": "object", "required": ["type", "content"],
+        }},
+    },
+}
+
+
+def default_scorers():
+    return (
+        [JsonSchemaScorer(schema=_LANGGRAPH_OUTPUT_SCHEMA, name="langgraph_messages_shape")],
+        [LatencyBudgetScorer(budget_ms=30_000, name="run_latency_30s")],
     )
 ```
 
 Things worth noting:
 
-- **Stable `step_id`s, not "step_N".** The schema reasons about "did the same step run last time?" via `step_id`, so meaningful names (`analyze`, `verify_claims`) outlive renames in the source pipeline.
-- **`executor` matches the source agent's filename stem** — adapter-guide readers and ops folks see the same names in pipewise reports as in `.claude/agents/`.
-- **Timestamps are synthesized** because FactSpark doesn't record per-step start times. The adapter uses each step file's mtime as a stand-in. This is a common shape for Claude-Code-orchestrated pipelines (no per-call telemetry; see "Cost capture" below).
-- **Mid-run failure is recorded, not raised.** A missing step file becomes `status="failed"` with an `error` message; the run continues and is marked `status="partial"`.
+- **`load_run` is one line.** Run-time mess (LLM calls, framework SDK, message normalization) lives in `capture.py`. Eval-time `adapter.py` is purely deterministic. This is the pattern the §"Capture vs adapter" section recommends; it falls out naturally when a framework already produces structured run state.
+- **`<node>__N` step_ids are an adapter-side convention,** not a pipewise core concept. Always-suffixed (single-fire nodes get `__1` too) so adapter code never branches on iteration count.
+- **Skipped nodes are explicit.** Walking the compiled graph's topology after streaming lets the adapter record any node that never fired with `status="skipped"`. A scorer can then spot a run that *should* have invoked tools but didn't.
+- **Per-step latency is not measured.** `stream_mode="updates"` yields each chunk *after* its node has finished; the timestamp the chunk was received is the only signal available. Run-level latency is the honest cap. The adapter records `latency_ms=None` per step rather than fabricating a number.
 
-## Worked example 2 — resume-tailor (branching pipeline)
+## Worked example 2 — imperative-loop agent (Anthropic SDK)
 
-The resume-tailor pipeline is a 7-step Claude Code agent system that tailors a resume to a specific job posting. Compared to FactSpark, it stresses three additional schema-level concerns:
+The Anthropic Quickstarts reference adapter targets a hand-rolled agent loop in the shape of the upstream [`agents`](https://github.com/anthropics/anthropic-quickstarts/tree/main/agents) Quickstart — a `while True:` over `client.messages.create(...)` that keeps appending tool results until the model stops emitting `tool_use` blocks. The same iteration-naming convention as worked example 1 (`<step>__N`, always suffixed) covers both the agent step and each tool execution.
 
-- **Optional steps:** step 2 (discover experience) is sometimes skipped for straightforward roles.
-- **Branching / conditional steps:** step 4 (write chronological resume) and step 4b (write hybrid resume) are mutually exclusive — both write to `step4.json`, distinguished by a `resume_format` field.
-- **Mixed JSON / Markdown:** steps 1-5 are JSON; step 6 produces cover-letter and application-response Markdown; step 7 (Canva export) has no filesystem output.
+Lives at [`examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/`](../examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/). Because upstream's `agents` Quickstart [explicitly is not packaged for installation](https://github.com/anthropics/anthropic-quickstarts/tree/main/agents), the adapter ships a small bundled `MinimalAgent` that mirrors upstream's loop shape — adopters with their own production agent code skip this and apply the same capture pattern to their existing loop directly.
 
-The adapter (lives at `job-search/integrations/pipewise/resume_tailor_pipewise/adapter.py` — public alongside pipewise v1.0) records the conditional shape by **always emitting both step IDs** with one marked `status="skipped"`:
+The structurally interesting bit is how capture observes each LLM call and tool call via an event sink the agent calls inline:
 
-```python
-# resume_tailor_pipewise/adapter.py — abridged
-chronological_taken, _ = _resolve_step4_format(step3, step4)
-
-if chronological_taken:
-    steps.append(_make_step(
-        step_id="write_resume_chronological",
-        step_name="Write Resume (Chronological)",
-        executor="resume-step4-write-resume",
-        started_at=at(30), duration_s=5, status="completed", outputs=step4,
-    ))
-    steps.append(_make_step(
-        step_id="write_resume_hybrid",
-        step_name="Write Resume (Hybrid)",
-        executor="resume-step4b-write-resume-hybrid",
-        started_at=at(40), duration_s=0, status="skipped",
-    ))
-else:  # hybrid taken
-    steps.append(_make_step(
-        step_id="write_resume_chronological",
-        step_name="Write Resume (Chronological)",
-        executor="resume-step4-write-resume",
-        started_at=at(30), duration_s=0, status="skipped",
-    ))
-    steps.append(_make_step(
-        step_id="write_resume_hybrid",
-        step_name="Write Resume (Hybrid)",
-        executor="resume-step4b-write-resume-hybrid",
-        started_at=at(40), duration_s=5, status="completed", outputs=step4,
-    ))
-```
-
-The two-step-IDs-with-one-skipped pattern is what lets `pipewise diff` surface a format flip between runs as a status change — the most readable kind of regression signal.
-
-For the optional-step case (step 2), the adapter emits a single step entry whose status switches with the source data:
+### Capture half
 
 ```python
-if step2 is None:                           # step2.json absent on disk
-    steps.append(_make_step(step_id="discover_experience", status="skipped", ...))
-else:
-    steps.append(_make_step(step_id="discover_experience", status="completed", outputs=step2, ...))
+# pipewise_anthropic_quickstarts/capture.py — abridged
+from collections import defaultdict
+from datetime import UTC, datetime
+import time
+
+from pipewise.core.schema import PipelineRun, StepExecution
+from .agent import MinimalAgent
+from .pricing import estimate_cost_usd
+
+
+def capture_run(client, user_input, *, run_id, pipeline_name, system,
+                tool_schemas, tool_executors,
+                pipeline_version="0.1.0", adapter_version="0.1.0",
+                model=None) -> PipelineRun:
+    agent = MinimalAgent(client=client, system=system,
+                        tool_schemas=tool_schemas, tool_executors=tool_executors,
+                        **({"model": model} if model else {}))
+
+    started_at = datetime.now(UTC)
+    t_run_start = time.perf_counter()
+
+    iteration_counter: dict[str, int] = defaultdict(int)
+    steps: list[StepExecution] = []
+
+    def sink(event_kind: str, event_data: dict) -> None:
+        captured_at = datetime.now(UTC)
+        if event_kind == "llm_call":
+            response = event_data["response"]
+            iteration_counter["agent"] += 1
+            n = iteration_counter["agent"]
+            usage = getattr(response, "usage", None)
+            input_tokens = int(getattr(usage, "input_tokens", 0) or 0) if usage else 0
+            output_tokens = int(getattr(usage, "output_tokens", 0) or 0) if usage else 0
+            steps.append(StepExecution(
+                step_id=f"agent__{n}",
+                step_name=f"Agent (iteration {n})",
+                executor="agent",
+                model=getattr(response, "model", None), provider="anthropic",
+                inputs={"messages": event_data["messages_in"]},
+                outputs=_serialize_response(response),
+                started_at=captured_at, completed_at=captured_at,
+                status="completed",
+                input_tokens=input_tokens or None,
+                output_tokens=output_tokens or None,
+                cost_usd=estimate_cost_usd(
+                    getattr(response, "model", "") or "",
+                    input_tokens, output_tokens,
+                ),
+            ))
+        elif event_kind == "tool_call":
+            name = event_data["name"]
+            iteration_counter[name] += 1
+            n = iteration_counter[name]
+            steps.append(StepExecution(
+                step_id=f"{name}__{n}",
+                step_name=f"{name.replace('_', ' ').title()} (iteration {n})",
+                executor=name, provider="anthropic",
+                inputs={"input": event_data.get("input"),
+                        "tool_use_id": event_data.get("id")},
+                outputs={"output": event_data.get("output")},
+                started_at=captured_at, completed_at=captured_at,
+                status="completed",
+            ))
+
+    final_text = agent.run(user_input, sink=sink)
+    total_latency_ms = int((time.perf_counter() - t_run_start) * 1000)
+
+    return PipelineRun(
+        run_id=run_id, pipeline_name=pipeline_name,
+        adapter_name="pipewise-anthropic-quickstarts", adapter_version="0.1.0",
+        started_at=started_at, completed_at=datetime.now(UTC),
+        status="completed",
+        initial_input={"user_input": user_input},
+        steps=steps,
+        total_input_tokens=sum(s.input_tokens or 0 for s in steps) or None,
+        total_output_tokens=sum(s.output_tokens or 0 for s in steps) or None,
+        total_cost_usd=sum((s.cost_usd or 0.0) for s in steps) or None,
+        total_latency_ms=total_latency_ms,
+        final_output={"text": final_text},
+    )
 ```
 
-For step 7 (apply_to_canva), the adapter always emits `status="skipped"` because the canonical store is Canva, not the filesystem. This makes the pipeline's true shape visible in pipewise reports — operators reading the report shouldn't have to remember "Canva exists outside our schema."
+### Eval-time adapter
+
+```python
+# pipewise_anthropic_quickstarts/adapter.py — full
+from pathlib import Path
+
+from pipewise.core.schema import PipelineRun
+from pipewise.scorers.budget import CostBudgetScorer, LatencyBudgetScorer
+from pipewise.scorers.json_schema import JsonSchemaScorer
+
+
+def load_run(path: str | Path) -> PipelineRun:
+    return PipelineRun.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+_AGENT_OUTPUT_SCHEMA = {
+    "type": "object",
+    "required": ["content", "stop_reason"],
+    "properties": {
+        "content": {"type": "array", "items": {
+            "type": "object", "required": ["type"],
+        }},
+        "stop_reason": {"type": ["string", "null"]},
+    },
+}
+
+
+def default_scorers():
+    return (
+        [JsonSchemaScorer(
+            schema=_AGENT_OUTPUT_SCHEMA,
+            name="anthropic_agent_response_shape",
+            applies_to_step_ids=[f"agent__{i}" for i in range(1, 9)],
+        )],
+        [
+            LatencyBudgetScorer(budget_ms=60_000, name="run_latency_60s"),
+            CostBudgetScorer(budget_usd=0.10, on_missing="skip", name="run_cost_10c"),
+        ],
+    )
+```
+
+Things worth noting:
+
+- **The sink is the integration surface.** `MinimalAgent.run(...)` exposes a callback hook that fires once per LLM call and once per tool call. Capture is just two `if event_kind == ...` branches. Adopters with their own production agent code apply the same pattern: pass a sink-shaped callback into your existing agent and let it record `StepExecution`s as the loop runs.
+- **Per-tool step_ids.** A run that calls `calculator` twice produces `calculator__1` and `calculator__2`. A regression where the agent stops calling `lookup_country` shows up as a missing `lookup_country__1` step rather than as a subtle output diff.
+- **Cost is captured, latency is not.** `Message.usage` exposes input/output tokens directly; combined with a small per-model price table (`pricing.py`), per-step `cost_usd` round-trips meaningfully. Per-step latency is left `None` for the same reason as worked example 1 — the sink fires after each call completes, so duration isn't observable from outside.
+- **`applies_to_step_ids` scopes the agent-shape scorer** to `agent__1..8` (matching the agent's `DEFAULT_MAX_ITERATIONS`). Tool steps have a different output shape and would fail the schema; the runner auto-skips them. See the §"Runner skip semantics" section below for details.
 
 ## The `default_scorers()` contract
 
-`default_scorers()` returns the canonical scorer set used by `pipewise eval` when no `--scorers <toml>` is supplied. Both reference adapters follow the same pattern:
+`default_scorers()` returns the canonical scorer set used by `pipewise eval` when no `--scorers <toml>` is supplied. The two reference adapters demonstrate the same conventions with different scorer choices:
 
 ```python
-def default_scorers() -> tuple[list[StepScorer], list[RunScorer]]:
-    step_scorers: list[StepScorer] = [
-        RegexScorer(field="full_article_content", pattern=r".{100,}",
-                    name="article-body-present"),
-    ]
-    run_scorers: list[RunScorer] = [
-        CostBudgetScorer(budget_usd=1.0,    on_missing="skip", name="cost-cap"),
-        LatencyBudgetScorer(budget_ms=120_000, on_missing="skip", name="latency-cap"),
-    ]
-    return step_scorers, run_scorers
+# pipewise_langgraph/adapter.py — default_scorers
+def default_scorers():
+    return (
+        [JsonSchemaScorer(schema=_LANGGRAPH_OUTPUT_SCHEMA,
+                          name="langgraph_messages_shape")],
+        [LatencyBudgetScorer(budget_ms=30_000, name="run_latency_30s")],
+    )
+
+# pipewise_anthropic_quickstarts/adapter.py — default_scorers
+def default_scorers():
+    return (
+        [JsonSchemaScorer(
+            schema=_AGENT_OUTPUT_SCHEMA,
+            name="anthropic_agent_response_shape",
+            applies_to_step_ids=[f"agent__{i}" for i in range(1, 9)],
+        )],
+        [
+            LatencyBudgetScorer(budget_ms=60_000, name="run_latency_60s"),
+            CostBudgetScorer(budget_usd=0.10, on_missing="skip", name="run_cost_10c"),
+        ],
+    )
 ```
 
-**Convention: exclude `LlmJudgeScorer` from defaults.** It's the only built-in scorer that calls a paid API, and surprise costs hurt UX for first-time users. Power users opt in explicitly via `pipewise eval --scorers <toml>`. (See `docs/scorers.md` for the matching guidance on scorer config files.)
+**Convention: exclude `LlmJudgeScorer` from defaults.** It's the only built-in scorer that calls a paid API, and surprise costs hurt UX for first-time users. Power users opt in explicitly via `pipewise eval --scorers <toml>`. (See [`docs/scorers.md`](scorers.md) for the matching guidance on scorer config files.)
 
-**Convention: pick step-level scorers that produce a meaningful pass/fail signal, not all-pass-or-all-fail.** FactSpark's `article-body-present` regex passes on steps 1-6 (where `full_article_content` propagates) and fails on step 7 (different schema) — six passes plus one fail per run is a real eval signature, and a future regression that breaks propagation surfaces immediately. For the resume-tailor adapter, the equivalent is an adapter-derived `_company` field flattened onto every step's outputs, which produces an all-passing baseline on the steps that ran (steps with `status="skipped"` are auto-skipped by the runner — see "Runner skip semantics" below).
+**Convention: pick step-level scorers that produce a meaningful pass/fail signal.** A `JsonSchemaScorer` over the canonical step-output shape catches adapter regressions that mangle or drop messages — a stronger guardrail than a tautological "the step has outputs" check. The LangGraph adapter validates that every non-skipped step's outputs conform to LangGraph's `{messages: [{type, content}, …]}` shape; the Anthropic adapter validates that each agent step has a `content` array and a `stop_reason`. Both surface real bugs (a capture that lost a tool-call message; a serializer that dropped `stop_reason`).
 
-**Convention: use `applies_to_step_ids` to scope step scorers honestly.** A scorer that only makes sense on certain step types (e.g., a regex against `full_article_content` that step 7 doesn't carry) should declare its scope via the `applies_to_step_ids` kwarg rather than letting failures pile up on out-of-scope steps:
+**Convention: use `applies_to_step_ids` to scope step scorers honestly.** A scorer that only makes sense on certain step types (e.g., the Anthropic agent-shape scorer that only applies to `agent__N` steps, not tool steps) should declare its scope via the `applies_to_step_ids` kwarg rather than letting failures pile up on out-of-scope steps:
 
 ```python
-RegexScorer(
-    field="full_article_content",
-    pattern=r".{100,}",
-    name="article-body-present",
-    applies_to_step_ids=["analyze", "enhance_entities", "enhance_content",
-                         "enhance_source", "stupid_meter",
-                         "enhance_analytics_ui"],  # excludes "verify_claims"
+JsonSchemaScorer(
+    schema=_AGENT_OUTPUT_SCHEMA,
+    name="anthropic_agent_response_shape",
+    applies_to_step_ids=[f"agent__{i}" for i in range(1, 9)],  # NOT calculator__N etc.
 )
 ```
 
-The runner emits `status="skipped"` for any step not listed, without invoking the scorer. Reports stay readable: "this scorer covered six of seven steps" is a real eval shape, where the alternative "every step shows the scorer passed" was incorrect when step 7 had no `full_article_content` to validate. See `docs/scorers.md` for the full skipped-state semantics.
+The runner emits `status="skipped"` for any step not listed, without invoking the scorer. Reports stay readable: "this scorer covered each agent iteration that actually fired" is a real eval shape, where the alternative "the schema scorer failed on every tool step" would be incorrect noise. See [`docs/scorers.md`](scorers.md) for the full skipped-state semantics.
 
-**Convention: budget scorers use `on_missing="skip"` when cost / latency data isn't available.** Both reference pipelines run inside Claude Code, which doesn't currently expose per-agent usage telemetry to user code — see the "Cost capture status" section in pipewise's README for the full deferral story. Adapters set `cost_usd` / `latency_ms` to `None` and rely on `on_missing="skip"` so the budget scorers emit `status="skipped"` (no signal) instead of producing fake passes. When telemetry becomes available, the only change needed is `on_missing="fail"`.
+**Convention: budget scorers use `on_missing="skip"` when the underlying datum isn't always available.** Both reference adapters capture `input_tokens` and `output_tokens` per LLM-call step from the framework's native usage signal, but `cost_usd` requires a per-model price table and falls back to `None` for unknown models. The Anthropic `CostBudgetScorer` is configured with `on_missing="skip"` so unrecognized-model runs emit `status="skipped"` (no signal) rather than fabricating a pass or fail. The same pattern applies to any pipeline whose telemetry is incomplete — set `None` honestly, configure `on_missing="skip"`, and signal lights up automatically as data becomes available.
 
 ### Runner skip semantics
 
@@ -377,24 +544,39 @@ This means adapters do not need to filter scorers or step lists themselves to ex
 
 ## Cost / latency / tokens
 
-Pipewise's schema has first-class fields for cost, latency, and token counts (`StepExecution.cost_usd`, `latency_ms`, `input_tokens`, `output_tokens`, plus run-level totals). When your pipeline captures this data, populate it — the budget scorers and any future cost-aware reporting come along for free.
+Pipewise's schema has first-class fields for cost, latency, and token counts (`StepExecution.cost_usd`, `latency_ms`, `input_tokens`, `output_tokens`, plus run-level totals). When your pipeline captures this data, populate it — the budget scorers and any future cost-aware reporting come along for free. Both reference adapters capture per-step input/output tokens directly from the framework's native usage signal, and the Anthropic adapter computes per-step `cost_usd` via a small price table.
 
-When your pipeline *doesn't* capture this data (e.g., Claude Code agents in v1), leave those fields as `None` and use `on_missing="skip"` on the budget scorers. Pipewise's schema is forward-compatible: turning the data on later is purely additive — no adapter contract changes, no schema migrations.
+What's measurable from outside the pipeline depends on the framework. **Per-step latency is honest-`None`** for both reference adapters: each chunk arrives *after* its node has finished (LangGraph's `stream_mode="updates"`) or each event fires after the LLM/tool call has returned (the Anthropic agent's sink), so duration is not measurable from outside. Run-level latency is wall-clock and meaningful in both cases. **Per-step `cost_usd`** requires either a billing API or a price-table lookup; the Anthropic adapter does the latter and falls back to `None` for unknown models.
+
+When your pipeline doesn't capture a particular signal, leave those fields as `None` and use `on_missing="skip"` on the budget scorers. Pipewise's schema is forward-compatible: turning the data on later is purely additive — no adapter contract changes, no schema migrations.
 
 ## Testing your adapter
 
-Both reference adapters ship with a `tests/test_adapter.py` covering:
+Both reference adapters ship a `tests/test_adapter.py` organized into three classes; each new adapter should mirror the same shape.
 
-- `load_run` against synthetic step files in `tmp_path` (always-runs)
-- `load_run` against real pipeline output (skipped when the canonical local data isn't present)
-- `default_scorers()` shape: list types, no `LlmJudgeScorer`, budget scorers use `on_missing="skip"`
-- End-to-end `run_eval` round-trip against synthetic runs
+```python
+class TestLoadRun:
+    def test_loads_iteration_capture(self): ...    # parses a real captured run
+    def test_loads_skipped_capture(self): ...      # parses a run with skipped steps
+    def test_accepts_string_path(self): ...        # adapter accepts str + Path
+    def test_raises_on_missing_file(self): ...     # surfaces a clean error
 
-Pipewise itself ships matching gate tests in `tests/integration/test_phase4_*_gate.py` that drive `pipewise.run_eval` through the production adapters end-to-end on real pipeline data — they skip cleanly on contributor machines without local pipeline data.
+class TestDefaultScorers:
+    def test_returns_step_and_run_scorers(self): ...   # tuple shape, list contents
+    def test_scorer_names_stable(self): ...            # names round-trip into reports
+
+class TestEndToEndEval:
+    def test_iteration_run_passes_all_step_scorers(self): ...   # run_eval round-trip
+    def test_skipped_step_results_in_skipped_score(self): ...   # status passes through
+```
+
+Both adapters' suites run without LLM calls — the captured `golden-*.json` runs under each adapter's `runs/` directory are the test fixtures. Re-running `capture_runs.py` regenerates them and is the only place where actual API calls happen.
+
+When you add an adapter to your own pipeline, point its tests at runs your pipeline has already captured. The test suites in `examples/langgraph/tests/` and `examples/anthropic-quickstarts/tests/` are good starting points to copy.
 
 ## Reference adapters
 
-Both reference adapters ship in their own pipeline repos and go public alongside pipewise v1.0. See [`examples/README.md`](../examples/README.md) for the canonical list, and [`docs/schema.md`](schema.md) for the field-by-field schema reference.
+See [`examples/README.md`](../examples/README.md) for the canonical inventory, and [`docs/schema.md`](schema.md) for the field-by-field schema reference.
 
-- **FactSpark** — linear-ish 7-step news-analysis pipeline, mixed Anthropic / Google models
-- **Resume-tailor** — branching/conditional pipeline with optional steps and Markdown side-products
+- **`pipewise-langgraph`** ([`examples/langgraph/`](../examples/langgraph/)) — declarative-graph agent (LangGraph `create_react_agent`). Demonstrates: iterated graph nodes, explicit-skipped semantics for unfired topology nodes, per-step token capture from `AIMessage.usage_metadata`.
+- **`pipewise-anthropic-quickstarts`** ([`examples/anthropic-quickstarts/`](../examples/anthropic-quickstarts/)) — imperative-loop agent (Anthropic SDK in the shape of the upstream `agents` Quickstart). Demonstrates: per-tool step_ids, per-step cost via a small price table, sink-callback integration with an existing agent loop.


### PR DESCRIPTION
## Summary

Phase 5.5.5 PR 2 of 4. Replaces the two worked-example sections in `docs/adapter-guide.md` with the shipped reference adapters and adds a new short architectural section on the run-time/eval-time split.

## What changed

- **§"Capture vs adapter: run-time / eval-time split" (NEW).** Teaches the pattern both new reference adapters use — `capture.py` (run-time, may call LLMs) writes a complete `PipelineRun` JSON; `adapter.py` (eval-time, deterministic) is a one-line `model_validate_json` plus `default_scorers`. The in-`load_run`-translation pattern is acknowledged as a fallback for pre-existing on-disk formats.
- **§6 — Worked example 1: declarative-graph agent (LangGraph).** Shows abridged `capture_run` (graph stream + topology walk for skipped nodes) and the full eval-time adapter (`JsonSchemaScorer` + `LatencyBudgetScorer`).
- **§7 — Worked example 2: imperative-loop agent (Anthropic SDK).** Shows abridged `capture_run` (sink callback over `MinimalAgent.run`) and the full adapter (`anthropic_agent_response_shape` scoped to `agent__1..8`, `Latency` + `CostBudgetScorer` with `on_missing="skip"`).
- **§"Why the adapter lives in your repo".** Updated to acknowledge the in-tree-subpackage carve-out for OSS reference adapters (matches `CLAUDE.md` after PR #83).
- **§"`default_scorers()` contract".** Replaced FactSpark-flavored examples with both adapters' actual scorer suites; rewrote the `applies_to_step_ids` guidance around the real Anthropic agent-shape scorer scope.
- **§"Cost / latency / tokens".** Reframed from "Claude Code v1 doesn't capture telemetry" to "what's measurable depends on the framework" — both new adapters DO capture per-step tokens; the Anthropic adapter computes per-step cost; per-step latency is honest-`None` for both (chunk/event fires after the call returns).
- **§"Testing your adapter".** Generalized to the three-class test pattern both adapters use: `TestLoadRun` / `TestDefaultScorers` / `TestEndToEndEval`.
- **§"Reference adapters" trailing list.** Rewritten around the two new in-tree subpackages.

Net diff: +306 / −124, only `docs/adapter-guide.md` modified.

## Verification

All abridged Python excerpts cross-checked against the shipped adapter source via `uv run python`:
- `load_run` works on both adapters' captured golden runs
- `default_scorers()` names verified (`langgraph_messages_shape`, `run_latency_30s`, `anthropic_agent_response_shape`, `run_latency_60s`, `run_cost_10c`)
- `applies_to_step_ids = [f"agent__{i}" for i in range(1, 9)]` matches `DEFAULT_MAX_ITERATIONS = 8` in `agent.py`

Privacy + public-surface review (privacy-reviewer subagent): clean. Zero schema-leak hits across the full PIVOT_PLAN §7 pattern list. One fidelity nit on capture-function `**versions` shorthand applied before commit (now explicit `pipeline_version` / `adapter_version` kwargs).

Pre-push: `ruff format --check .` / `ruff check .` / `mypy pipewise/` / `pytest -q` (452 passed, 1 skipped) — all green.

## Test plan

- [x] All abridged code excerpts represent the shipped adapter source faithfully
- [x] No legacy schema-leak identifiers remain (PIVOT_PLAN §7 grep)
- [x] All cross-reference links resolve
- [x] `ruff format` / `ruff check` / `mypy` / `pytest` all green
- [ ] CI green on the open PR (short-circuits via PR #85's path-filter — this is doc-only)

## Sequence

Phase 5.5.5 PR **2 of 4**. Remaining: PR 3 (`docs/ci-integration.md`), PR 4 (`README.md` + `CHANGELOG.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)