### PR TITLE
docs(ci-integration): fix-ups from post-merge Gemini PR #87 review

### DIFF
--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -25,7 +25,7 @@ A single sticky comment per adapter on every PR, updated in place across pushes:
 
 **Regressions:** 0 🔴 · **Improvements:** 2 🟢 · **Unchanged:** 2
 
-<details><summary>Full report (2 runs · dataset: golden.jsonl)</summary>
+<details><summary>Full report (1 run · dataset: golden.jsonl)</summary>
 …
 </details>
 
@@ -316,7 +316,7 @@ For the full set of states the renderer handles (passing-no-change, passing-impr
 - **Canonical dataset:** the two committed golden runs at [`examples/anthropic-quickstarts/runs/`](../examples/anthropic-quickstarts/runs/) — `golden-001-iteration.json` (multi-iteration agent loop with two parallel tool calls) and `golden-002-skipped.json` (greeting input, no tool calls). Together they exercise iteration, per-tool steps, and an agent that stops on `end_turn` without using tools.
 - **Adapter name:** `pipewise_anthropic_quickstarts`.
 - **Baseline retention:** 90 days (default).
-- **Default scorer suite:** `anthropic_agent_response_shape` (step, scoped to `agent__1..8` matching the agent's `DEFAULT_MAX_ITERATIONS`), `run_latency_60s`, `run_cost_10c` with `on_missing="skip"`. See [`examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/adapter.py`](../examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/adapter.py) for the source.
+- **Default scorer suite:** `anthropic_agent_response_shape` (step, scoped to `agent__1..8` matching the agent's `DEFAULT_MAX_ITERATIONS`), `run_latency_60s`, and `run_cost_10c` (with `on_missing="skip"` so unrecognized-model runs short-circuit instead of failing). See [`examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/adapter.py`](../examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/adapter.py) for the source.
 
 For the LangGraph reference adapter, the same pattern applies — substitute `pipewise_langgraph` for the adapter name and point at [`examples/langgraph/runs/`](../examples/langgraph/runs/) for the dataset.
 


### PR DESCRIPTION
## Summary

Two valid Gemini Code Assist comments arrived on PR #87 after it merged. Both are real issues; both fixed here.

## What changed

1. **Illustrative example "2 runs" inconsistency** (line 28). The summary said "Full report (2 runs · dataset: golden.jsonl)" but the counts row (\`Improvements: 2 · Unchanged: 2\`) summed to 4 individual results. \`pipewise.ci.github_action.render_pr_comment()\` counts \`(run, step, scorer)\` triples across all runs, not per-row aggregates, so 4 results = 1 run × 4 scorers. Changed "2 runs" → "1 run" so the arithmetic reconciles. The regression example immediately below it already correctly reads "1 run".

2. **Worked-example trailing bullet ambiguity** (line 319). "\`run_latency_60s\`, \`run_cost_10c\` with \`on_missing=\"skip\"\`" implied both scorers shared the setting; in fact only \`run_cost_10c\` is configured with \`on_missing="skip"\`. Rephrased so the scope is explicit and the rationale (unrecognized-model short-circuit) is stated inline.

Net diff: +2 / −2.

## Verification

Both fixes verified against \`examples/anthropic-quickstarts/pipewise_anthropic_quickstarts/adapter.py\` — only \`CostBudgetScorer\` carries \`on_missing="skip"\`. Pre-push checks omitted (one-line phrasing fixes; no code touched).

## Test plan

- [x] Both Gemini comments addressed
- [x] Counts arithmetic now reconciles in both examples
- [x] \`on_missing="skip"\` scope is unambiguous
- [ ] CI green (will short-circuit via PR #85's path filter — doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)