### PR TITLE
ci: bump checkout + setup-uv to Node 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install uv
         if: steps.changes.outputs.core == 'true'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Summary

- `actions/checkout` was already at `@v6` (Node 24) — no change needed there.
- `astral-sh/setup-uv@v7` → `astral-sh/setup-uv@v8.1.0` (Node 24)

## Node 20 → Node 24 deadline context

GitHub is deprecating Node.js 20 in GitHub Actions runners:
- **June 2, 2026** — Node 24 becomes the forced default for JavaScript actions
- **September 16, 2026** — Node 20 is removed from runners entirely

`setup-uv@v7` uses `node20` in its `action.yml`; `v8.1.0` (released April 16, 2025) uses `node24`. This PR eliminates the pending deprecation warning and ensures CI keeps running after the September deadline.

## Version pinning note

`astral-sh/setup-uv` v8.0.0 dropped floating major/minor tags (e.g. `@v8`) as a supply-chain security measure (the tj-actions incident). Exact version pins are now required. This PR uses `@v8.1.0` (the current latest).

## What is unchanged

Everything else in `.github/workflows/ci.yml` is untouched: the Python 3.11/3.12 matrix, ruff lint + format checks, mypy strict, pytest, the path-filter short-circuit logic, and the `enable-cache: true` setting (still compatible with `uv.lock`).

---
_Generated by [Claude Code](https://claude.ai/code/session_017nav2fW294mtFgtuoz8G3e)_